### PR TITLE
feat: add login widget package

### DIFF
--- a/packages/login_widget/analysis_options.yaml
+++ b/packages/login_widget/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/login_widget/lib/login_widget.dart
+++ b/packages/login_widget/lib/login_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class LoginWidget extends StatefulWidget {
+  const LoginWidget({super.key, required this.onLogin});
+
+  final void Function(String username, String password) onLogin;
+
+  @override
+  State<LoginWidget> createState() => _LoginWidgetState();
+}
+
+class _LoginWidgetState extends State<LoginWidget> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _handleLogin() {
+    widget.onLogin(
+      _usernameController.text,
+      _passwordController.text,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextField(
+          controller: _usernameController,
+          decoration: const InputDecoration(labelText: 'Username'),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: _passwordController,
+          decoration: const InputDecoration(labelText: 'Password'),
+          obscureText: true,
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton(
+          onPressed: _handleLogin,
+          child: const Text('Login'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/login_widget/pubspec.yaml
+++ b/packages/login_widget/pubspec.yaml
@@ -1,0 +1,19 @@
+name: login_widget
+description: A simple login widget package.
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.0.6 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: false

--- a/packages/login_widget/test/login_widget_test.dart
+++ b/packages/login_widget/test/login_widget_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:login_widget/login_widget.dart';
+
+void main() {
+  testWidgets('LoginWidget calls onLogin with input values', (WidgetTester tester) async {
+    String? username;
+    String? password;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LoginWidget(
+            onLogin: (u, p) {
+              username = u;
+              password = p;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField).at(0), 'user');
+    await tester.enterText(find.byType(TextField).at(1), 'pass');
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+
+    expect(username, 'user');
+    expect(password, 'pass');
+  });
+}


### PR DESCRIPTION
## Summary
- add `login_widget` package for a simple login UI
- include widget test verifying onLogin callback

## Testing
- `flutter test packages/login_widget` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b973d6925c832aaf2bc45a0525c821