### PR TITLE
feat: add reusable login button widget

### DIFF
--- a/packages/login_button/README.md
+++ b/packages/login_button/README.md
@@ -1,0 +1,34 @@
+# LoginButton
+
+A reusable Flutter widget that displays a login button.
+
+## Features
+
+- Familiar API inspired by Flutter's [ElevatedButton](https://api.flutter.dev/flutter/material/ElevatedButton-class.html)
+- Inject tap behavior via the `onPressed` callback
+- Customize label, colors, size, and text style
+
+## Usage
+
+```
+LoginButton(
+  label: 'Sign in',
+  onPressed: () {
+    // Handle login action
+  },
+);
+```
+
+## Installation
+
+Add this package to your `melos` workspace or include it in your `pubspec.yaml`:
+
+```
+dependencies:
+  login_button:
+    path: ../packages/login_button
+```
+
+## License
+
+This project is licensed under the MIT License.

--- a/packages/login_button/lib/login_button.dart
+++ b/packages/login_button/lib/login_button.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// [LoginButton] is a reusable widget that displays a button typically used
+/// for login actions.
+///
+/// It mirrors the API of Flutter's [ElevatedButton] to provide a familiar
+/// interface. Consumers inject the tap behaviour via the [onPressed]
+/// callback.
+class LoginButton extends StatelessWidget {
+  /// Creates a [LoginButton].
+  const LoginButton({
+    super.key,
+    required this.onPressed,
+    this.label = 'Login',
+    this.backgroundColor,
+    this.textStyle,
+    this.width,
+    this.height,
+  });
+
+  /// Called when the button is tapped.
+  final VoidCallback onPressed;
+
+  /// The text label displayed inside the button. Defaults to `Login`.
+  final String label;
+
+  /// Background color of the button. If null, defaults to the theme's color.
+  final Color? backgroundColor;
+
+  /// Text style for the label.
+  final TextStyle? textStyle;
+
+  /// Optional width of the button.
+  final double? width;
+
+  /// Optional height of the button.
+  final double? height;
+
+  @override
+  Widget build(BuildContext context) {
+    final button = ElevatedButton(
+      onPressed: onPressed,
+      style: backgroundColor != null
+          ? ElevatedButton.styleFrom(backgroundColor: backgroundColor)
+          : null,
+      child: Text(label, style: textStyle),
+    );
+
+    if (width != null || height != null) {
+      return SizedBox(width: width, height: height, child: button);
+    }
+    return button;
+  }
+}

--- a/packages/login_button/pubspec.yaml
+++ b/packages/login_button/pubspec.yaml
@@ -1,0 +1,12 @@
+name: login_button
+description: A reusable login button widget.
+version: 0.1.0
+publish_to: none
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:


### PR DESCRIPTION
## Summary
- add reusable LoginButton widget with external onPressed injection
- document widget usage and customization options

## Testing
- `dart format packages/login_button/lib/login_button.dart` *(fails: command not found)*
- `flutter analyze packages/login_button` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bceeeefcf8832aa39fb5d36ac889c1