### PR TITLE
refactor: strengthen routes controller interface

### DIFF
--- a/apps/daily_memo/lib/core/di/service_locator.dart
+++ b/apps/daily_memo/lib/core/di/service_locator.dart
@@ -1,5 +1,4 @@
 import 'package:app_navigation/app_navigation.dart';
-import 'package:apps.daily_memo/core/route/app_routes.dart';
 import 'package:apps.daily_memo/data/repository_impl/memo/memo_repository_impl.dart';
 import 'package:apps.daily_memo/data/repository_interface/memo/memo_repository.dart';
 import 'package:apps.daily_memo/data/sql_helper.dart';
@@ -14,8 +13,6 @@ class ServiceLocator {
               () => SQLHelper())
       ..registerLazySingleton<RoutesController>(
         () => GoRouterRoutesController(
-          routesBuilder: () =>
-              AppRoutes.values.map((route) => route.getRouter).toList(),
           navigationType: GoRouterNavigationType.path,
           popAllStrategy: GoRouterPopAllStrategy.pushReplacement,
         ),

--- a/apps/daily_memo/lib/domain/bloc/home/home_bloc.dart
+++ b/apps/daily_memo/lib/domain/bloc/home/home_bloc.dart
@@ -26,7 +26,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     MoveToAddMemo event,
     Emitter<HomeState> emit,
   ) async {
-    routesController.toPushNamed(
+    routesController.push(
       event.context,
       AppRoutes.memo.path,
       extra: {

--- a/apps/daily_memo/lib/presentation/view/memo/memo_list_page.dart
+++ b/apps/daily_memo/lib/presentation/view/memo/memo_list_page.dart
@@ -52,8 +52,11 @@ class MemoListView extends StatelessWidget {
           memoInfo = null;
         }
 
-        routesController.toPushNamed(context, AppRoutes.memo.path,
-            extra: {"memoInfo": memoInfo});
+        routesController.push(
+          context,
+          AppRoutes.memo.path,
+          extra: {"memoInfo": memoInfo},
+        );
       },
       // .add(GetMemo(listItem.uniqueId)),
       onLongPress: () => showDialog(

--- a/packages/app_navigation/README.md
+++ b/packages/app_navigation/README.md
@@ -4,7 +4,7 @@ Shared navigation helpers for Spiral applications built on top of `go_router`.
 
 ## Features
 
-- Common `RoutesController` contract
+- Common `RoutesController` contract with stack inspection helpers
 - Configurable `GoRouterRoutesController` implementation supporting path or
   name based navigation strategies
 
@@ -12,7 +12,7 @@ Shared navigation helpers for Spiral applications built on top of `go_router`.
 
 ```dart
 final controller = GoRouterRoutesController(
-  routesBuilder: () => AppRoutes.values.map((route) => route.getRouter).toList(),
   navigationType: GoRouterNavigationType.path,
+  popAllStrategy: GoRouterPopAllStrategy.pushReplacement,
 );
 ```

--- a/packages/app_navigation/lib/src/go_router_routes_controller.dart
+++ b/packages/app_navigation/lib/src/go_router_routes_controller.dart
@@ -14,7 +14,7 @@ enum GoRouterNavigationType {
   name,
 }
 
-/// Strategy used when `popAllAndPush` is invoked.
+/// Strategy used when `RoutesController.replaceAllWith` is invoked.
 enum GoRouterPopAllStrategy {
   /// Pops all routes and navigates using [GoRouter.go] / [GoRouter.goNamed].
   navigate,
@@ -30,20 +30,15 @@ enum GoRouterPopAllStrategy {
 /// Default implementation of [RoutesController] backed by [GoRouter].
 class GoRouterRoutesController extends RoutesController {
   GoRouterRoutesController({
-    required List<GoRoute> Function() routesBuilder,
     this.navigationType = GoRouterNavigationType.path,
     this.popAllStrategy = GoRouterPopAllStrategy.navigate,
-  }) : _routesBuilder = routesBuilder;
-
-  final List<GoRoute> Function() _routesBuilder;
+  });
 
   /// Determines whether navigation methods expect a route [path] or [name].
   final GoRouterNavigationType navigationType;
 
-  /// Strategy applied when [RoutesController.popAllAndPush] is triggered.
+  /// Strategy applied when [RoutesController.replaceAllWith] is triggered.
   final GoRouterPopAllStrategy popAllStrategy;
-
-  GoRouter _createRouter() => GoRouter(routes: _routesBuilder());
 
   @override
   void exitApp({int code = 0}) {
@@ -51,75 +46,99 @@ class GoRouterRoutesController extends RoutesController {
   }
 
   @override
-  void pop<T>(BuildContext context, {T? result}) {
+  bool pop<T>(BuildContext context, {T? result}) {
+    if (!canPop(context)) {
+      return false;
+    }
+
     GoRouter.of(context).pop(result);
+    return true;
   }
 
   @override
-  void popAllAndPush<T>(BuildContext context, String path, {T? result}) {
+  Future<T?>? replaceAllWith<T>(
+    BuildContext context,
+    String target, {
+    Object? extra,
+  }) {
     switch (popAllStrategy) {
       case GoRouterPopAllStrategy.navigate:
         _popAll(context);
-        _navigate(context, path);
-        break;
+        return _navigate<T>(context, target, extra: extra);
       case GoRouterPopAllStrategy.push:
         _popAll(context);
-        _push(context, path);
-        break;
+        return _push<T>(context, target, extra: extra);
       case GoRouterPopAllStrategy.pushReplacement:
         if (navigationType == GoRouterNavigationType.name) {
           _popAll(context);
-          _navigate(context, path);
+          return _navigate<T>(context, target, extra: extra);
         } else {
-          context.pushReplacement(path);
+          return context.pushReplacement<T>(target, extra: extra);
         }
-        break;
     }
   }
 
   @override
-  void popUntil<T>(BuildContext context, String path, {T? result}) {
-    final GoRouter router = _createRouter();
-    while (router.canPop() && router.location != path) {
+  void popUntil<T>(BuildContext context, String target, {T? result}) {
+    while (canPop(context) && GoRouter.of(context).location != target) {
       GoRouter.of(context).pop(result);
     }
   }
 
   @override
-  void toNavigate<T>(BuildContext context, String path, {Map? extra}) {
-    _navigate(context, path, extra: extra);
+  Future<T?>? navigateTo<T>(
+    BuildContext context,
+    String target, {
+    Object? extra,
+  }) {
+    return _navigate<T>(context, target, extra: extra);
   }
 
   @override
-  void toPushNamed<T>(BuildContext context, String path, {Map? extra}) {
-    _push(context, path, extra: extra);
+  Future<T?>? push<T>(
+    BuildContext context,
+    String target, {
+    Object? extra,
+  }) {
+    return _push<T>(context, target, extra: extra);
   }
 
-  void _navigate(BuildContext context, String path, {Map? extra}) {
+  @override
+  bool canPop(BuildContext context) => GoRouter.of(context).canPop();
+
+  @override
+  String? currentLocation(BuildContext context) => GoRouter.of(context).location;
+
+  Future<T?>? _navigate<T>(
+    BuildContext context,
+    String target, {
+    Object? extra,
+  }) {
     switch (navigationType) {
       case GoRouterNavigationType.path:
-        context.go(path, extra: extra);
-        break;
+        context.go(target, extra: extra);
+        return null;
       case GoRouterNavigationType.name:
-        context.goNamed(path, extra: extra);
-        break;
+        context.goNamed(target, extra: extra);
+        return null;
     }
   }
 
-  void _push(BuildContext context, String path, {Map? extra}) {
+  Future<T?>? _push<T>(
+    BuildContext context,
+    String target, {
+    Object? extra,
+  }) {
     switch (navigationType) {
       case GoRouterNavigationType.path:
-        GoRouter.of(context).push(path, extra: extra);
-        break;
+        return GoRouter.of(context).push<T>(target, extra: extra);
       case GoRouterNavigationType.name:
-        context.pushNamed(path, extra: extra);
-        break;
+        return context.pushNamed<T>(target, extra: extra);
     }
   }
 
   void _popAll(BuildContext context) {
-    final GoRouter router = _createRouter();
-    while (router.canPop()) {
+    while (canPop(context)) {
       GoRouter.of(context).pop();
     }
   }

--- a/packages/app_navigation/lib/src/routes_controller.dart
+++ b/packages/app_navigation/lib/src/routes_controller.dart
@@ -1,41 +1,59 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 
 /// Contract for coordinating navigation from feature layers without
 /// depending on the concrete routing solution.
+///
+/// The interface intentionally focuses on the minimal behaviour any
+/// implementation must provide so that feature layers can rely on a
+/// consistent API regardless of the underlying navigation package.
 abstract class RoutesController {
-  /// Navigate to the provided [path] replacing the current location.
-  void toNavigate<T>(
+  /// Replaces the current location with [target].
+  ///
+  /// Returns a [FutureOr] that resolves when the operation completes. Some
+  /// navigation systems (such as [GoRouter.go]) complete synchronously while
+  /// others might expose asynchronous handles.
+  FutureOr<T?>? navigateTo<T>(
     BuildContext context,
-    String path, {
-    Map<dynamic, dynamic>? extra,
+    String target, {
+    Object? extra,
   });
 
-  /// Push a new location identified by [path] while keeping the current stack.
-  void toPushNamed<T>(
+  /// Pushes [target] on top of the current navigation stack.
+  FutureOr<T?>? push<T>(
     BuildContext context,
-    String path, {
-    Map<dynamic, dynamic>? extra,
+    String target, {
+    Object? extra,
   });
 
-  /// Pop the current location.
-  void pop<T>(
+  /// Attempts to pop the current location.
+  ///
+  /// Returns `true` when the pop operation has been executed.
+  bool pop<T>(
     BuildContext context, {
     T? result,
   });
 
-  /// Pop locations until [path] is reached.
+  /// Pops locations until [target] becomes the current location.
   void popUntil<T>(
     BuildContext context,
-    String path, {
+    String target, {
     T? result,
   });
 
-  /// Remove every location and push the provided [path].
-  void popAllAndPush<T>(
+  /// Clears the stack and navigates to [target].
+  FutureOr<T?>? replaceAllWith<T>(
     BuildContext context,
-    String path, {
-    T? result,
+    String target, {
+    Object? extra,
   });
+
+  /// Whether the current stack can be popped.
+  bool canPop(BuildContext context);
+
+  /// Returns the active navigation location if available.
+  String? currentLocation(BuildContext context);
 
   /// Exit the application process with the given [code].
   void exitApp({int code = 0});


### PR DESCRIPTION
## Summary
- expand the shared RoutesController contract to cover asynchronous navigation, stack inspection, and stack replacement helpers
- update the GoRouter-backed implementation and daily memo feature usage to comply with the stronger interface
- refresh package documentation to describe the new API surface

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dca8e4b07c832ab174efab95b78398