### PR TITLE
feat: add voice transcriber service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Flutter 기반의 Mono Repo 베이스, Clean Architecture 룰을 따르는 프�
 | Daily Memo | 간단한 메모를 작성하고 관리하는 개인용 노트 앱 | sqflite 로컬 DB를 통해 메모 CRUD를 수행하며 BLoC 로직으로 상태를 관리하고 GoRouter 로 화면을 구성합니다. |
 | Exchange Rate Calculator | 환율 조회 및 계산 기능을 제공하는 학습용 앱 | 싱글톤 저장소가 외부 API에서 환율 정보를 가져오고 Adapter 패턴으로 다양한 데이터 소스를 통합하며 GoRouter 기반 라우팅을 제공합니다. |
 | Spiral Trade Show | 서울시 전시 정보를 보여주는 홍보용 앱 | Dio HTTP 클라이언트와 보안 키를 활용해 공공 데이터 포털에서 전시 정보를 수집하고 Cubit 패턴으로 UI 상태를 갱신합니다. |
+| Voice Transcriber | 음성 녹음과 텍스트 변환을 지원하는 실험용 앱 | Clean Architecture 기반의 세션 단위 UseCase 설계를 통해 A/B 테스트용 변환 엔진(OpenAI vs 자체 모델)을 런타임에서 전환하고 자동 클립보드 복사를 제공합니다. |
 
 ## Daily Memo App
 - `sqflite`를 사용하는 `SQLHelper`를 통해 로컬 데이터베이스에 메모를 저장하고 CRUD 기능을 제공합니다.

--- a/apps/voice_transcriber/README.md
+++ b/apps/voice_transcriber/README.md
@@ -1,0 +1,54 @@
+# Voice Transcriber Service
+
+모노레포 내 신규 서비스인 **Voice Transcriber** 는 음성 녹음 → 텍스트 변환 → 클립보드/공유 흐름을 하나의 화면에서 제공하는 실험용 앱입니다. 최종 사용자는 음성 명령이나 디바이스 숏컷을 통해 녹음을 시작하고, 변환된 텍스트를 자동 복사 또는 공유 옵션으로 즉시 활용할 수 있습니다.
+
+## 아키텍처 개요
+
+- **Clean Architecture** 를 기반으로 Presentation / Domain / Data 계층을 분리했습니다.
+- `SpeechToTextGateway` 인터페이스 하나만으로 외부(앱)에서는 동일한 변환 진입점을 사용하도록 설계했습니다.
+- `VoiceSessionSettingsRepository` 를 통해 A/B 테스트용 변환 엔진(OpenAI vs 자체 모델)을 런타임에서 교체할 수 있습니다.
+- 모든 의존성은 `VoiceTranscriberDependencies.bootstrap()` 에서 조합하여 테스트와 배포 환경을 쉽게 분기할 수 있도록 했습니다.
+
+```
+VoiceTranscriberApp
+ └─ VoiceSessionCubit (Presentation)
+     ├─ StartRecordingUseCase
+     ├─ CompleteSessionUseCase
+     │    ├─ AudioRecorderRepository (Data → FakeAudioRecorderDataSource)
+     │    ├─ SpeechToTextGateway (Data → FakeOpenAi/FakeLocal)
+     │    └─ ClipboardRepository (플랫폼 채널)
+     └─ VoiceSessionSettingsRepository (Data → In-memory)
+```
+
+## 기능 흐름
+
+1. **녹음 시작**: `VoiceSessionCubit.startRecording()` → `StartRecordingUseCase` → `AudioRecorderRepository`
+2. **녹음 종료 & 변환**: `VoiceSessionCubit.completeSession()` → `CompleteSessionUseCase`
+   - 선택된 엔진 정보를 Settings Repository에서 가져옵니다.
+   - 변환이 완료되면 자동 클립보드 복사 여부를 확인하고 실행합니다.
+3. **결과 미리보기/편집**: `TextField` 를 통해 변환 결과를 즉시 수정할 수 있습니다.
+4. **클립보드 & 공유**: 수동 복사 버튼, 공유 옵션(Stub) 버튼을 제공합니다.
+
+## Stub 데이터 소스
+
+현재 레포에는 외부 API 키가 포함되지 않으므로 `Fake*` 데이터 소스를 사용하여 흐름만 검증합니다. 실제 배포 단계에서는 다음과 같이 교체할 수 있습니다.
+
+| 인터페이스 | Stub 구현 | 실제 구현 교체 포인트 |
+| --- | --- | --- |
+| `AudioRecorderRepository` | `FakeAudioRecorderDataSource` | `flutter_sound` 또는 플랫폼 채널 기반 Recorder |
+| `SpeechToTextGateway` | `FakeOpenAiSpeechToTextDataSource`, `FakeLocalSpeechToTextDataSource` | OpenAI API 연동 Adapter, On-device 모델 Runner |
+| `ClipboardRepository` | `ClipboardRepositoryImpl` | 현재도 실환경 사용 가능 |
+
+## 근거 있는 개선 사항
+
+- 기존 서비스들은 화면/로직이 1:1로 묶여 있는 경우가 많았는데, 이번 서비스는 **세션 단위 UseCase** 중심으로 상태를 관리해 장기적인 엔진 교체에 대비했습니다.
+- `VoiceSessionState` 는 `autoCopyEnabled`, `engine` 등 환경 설정 값을 함께 들고 있어 UI가 별도 Storage를 의존하지 않아도 됩니다.
+- A/B 테스트를 위한 엔진 전환을 Dropdown UI로 제공하고, Settings Repository에서 현재 선택을 단일화하였습니다.
+- README 수준에서 Stub → 실제 구현 교체 지점을 명확하게 기록하여 온보딩 시간을 단축했습니다.
+
+## 향후 과제
+
+- 플랫폼별 음성 명령/Shortcut 연동 (iOS Shortcuts, Android Quick Actions)
+- 외부 공유를 위한 Share Sheet 통합
+- 실제 음성 → 텍스트 모델 연동과 Latency 측정
+- 프라이버시 옵션(로컬 저장 여부, 자동 삭제 정책) 추가

--- a/apps/voice_transcriber/analysis_options.yaml
+++ b/apps/voice_transcriber/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - lib/**.g.dart
+    - lib/firebase_options.dart
+    - pubspec.yaml
+
+linter:
+  rules:

--- a/apps/voice_transcriber/lib/app/voice_transcriber_dependencies.dart
+++ b/apps/voice_transcriber/lib/app/voice_transcriber_dependencies.dart
@@ -1,0 +1,63 @@
+import '../features/session/data/datasources/fake_audio_recorder_datasource.dart';
+import '../features/session/data/datasources/fake_local_speech_to_text_datasource.dart';
+import '../features/session/data/datasources/fake_openai_speech_to_text_datasource.dart';
+import '../features/session/data/repositories/audio_recorder_repository_impl.dart';
+import '../features/session/data/repositories/clipboard_repository_impl.dart';
+import '../features/session/data/repositories/speech_to_text_gateway_impl.dart';
+import '../features/session/data/repositories/voice_session_settings_repository_impl.dart';
+import '../features/session/domain/entities/voice_session_status.dart';
+import '../features/session/domain/usecases/complete_session_use_case.dart';
+import '../features/session/domain/usecases/copy_to_clipboard_use_case.dart';
+import '../features/session/domain/usecases/load_session_settings_use_case.dart';
+import '../features/session/domain/usecases/select_engine_use_case.dart';
+import '../features/session/domain/usecases/start_recording_use_case.dart';
+import '../features/session/domain/usecases/toggle_auto_copy_use_case.dart';
+import '../features/session/domain/value_objects/transcription_engine.dart';
+import '../features/session/presentation/cubit/voice_session_cubit.dart';
+import '../features/session/presentation/cubit/voice_session_state.dart';
+
+class VoiceTranscriberDependencies {
+  VoiceTranscriberDependencies._(this.sessionCubit);
+
+  factory VoiceTranscriberDependencies.bootstrap() {
+    final settingsRepository = VoiceSessionSettingsRepositoryImpl();
+    final audioRecorderRepository = AudioRecorderRepositoryImpl(
+      FakeAudioRecorderDataSource(),
+    );
+    final speechGateway = SpeechToTextGatewayImpl(
+      FakeOpenAiSpeechToTextDataSource(),
+      FakeLocalSpeechToTextDataSource(),
+      settingsRepository,
+    );
+    final clipboardRepository = ClipboardRepositoryImpl();
+
+    final startRecording = StartRecordingUseCase(audioRecorderRepository);
+    final completeSession = CompleteSessionUseCase(
+      audioRecorderRepository,
+      speechGateway,
+      clipboardRepository,
+      settingsRepository,
+    );
+    final toggleAutoCopy = ToggleAutoCopyUseCase(settingsRepository);
+    final loadSettings = LoadSessionSettingsUseCase(settingsRepository);
+    final selectEngine = SelectEngineUseCase(settingsRepository);
+    final copyToClipboard = CopyToClipboardUseCase(clipboardRepository);
+
+    final cubit = VoiceSessionCubit(
+      const VoiceSessionState(
+        status: VoiceSessionStatus.idle,
+        engine: TranscriptionEngine.openAi,
+      ),
+      startRecording,
+      completeSession,
+      toggleAutoCopy,
+      loadSettings,
+      selectEngine,
+      copyToClipboard,
+    );
+
+    return VoiceTranscriberDependencies._(cubit);
+  }
+
+  final VoiceSessionCubit sessionCubit;
+}

--- a/apps/voice_transcriber/lib/features/session/data/datasources/fake_audio_recorder_datasource.dart
+++ b/apps/voice_transcriber/lib/features/session/data/datasources/fake_audio_recorder_datasource.dart
@@ -1,0 +1,18 @@
+import 'dart:math';
+
+import '../../domain/entities/audio_recording.dart';
+
+class FakeAudioRecorderDataSource {
+  Future<void> start() async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  }
+
+  Future<AudioRecording> stop() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    final random = Random();
+    return AudioRecording(
+      bytes: List<int>.generate(200, (_) => random.nextInt(255)),
+      duration: Duration(milliseconds: 600 + random.nextInt(1600)),
+    );
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/data/datasources/fake_local_speech_to_text_datasource.dart
+++ b/apps/voice_transcriber/lib/features/session/data/datasources/fake_local_speech_to_text_datasource.dart
@@ -1,0 +1,8 @@
+import '../../domain/entities/audio_recording.dart';
+
+class FakeLocalSpeechToTextDataSource {
+  Future<String> transcribe(AudioRecording recording) async {
+    await Future<void>.delayed(const Duration(milliseconds: 700));
+    return '로컬 모델이 ${recording.duration.inSeconds}초 분량의 음성을 처리했습니다.';
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/data/datasources/fake_openai_speech_to_text_datasource.dart
+++ b/apps/voice_transcriber/lib/features/session/data/datasources/fake_openai_speech_to_text_datasource.dart
@@ -1,0 +1,15 @@
+import 'dart:math';
+
+import '../../domain/entities/audio_recording.dart';
+
+class FakeOpenAiSpeechToTextDataSource {
+  Future<String> transcribe(AudioRecording recording) async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    final samples = <String>[
+      '회의록 초안입니다. 주요 안건은 음성 인식 품질 개선과 클립보드 자동 복사 고도화였습니다.',
+      '다음 작업을 위해 코드를 정리하고, 테스트 커버리지를 80% 이상 유지하세요.',
+      'OpenAI 음성 모델과 자체 모델의 비교를 위해 실험 로그를 기록합니다.',
+    ];
+    return samples[Random().nextInt(samples.length)];
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/data/repositories/audio_recorder_repository_impl.dart
+++ b/apps/voice_transcriber/lib/features/session/data/repositories/audio_recorder_repository_impl.dart
@@ -1,0 +1,19 @@
+import '../../domain/entities/audio_recording.dart';
+import '../../domain/repositories/audio_recorder_repository.dart';
+import '../datasources/fake_audio_recorder_datasource.dart';
+
+class AudioRecorderRepositoryImpl implements AudioRecorderRepository {
+  AudioRecorderRepositoryImpl(this._dataSource);
+
+  final FakeAudioRecorderDataSource _dataSource;
+
+  @override
+  Future<void> start() {
+    return _dataSource.start();
+  }
+
+  @override
+  Future<AudioRecording> stop() {
+    return _dataSource.stop();
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/data/repositories/clipboard_repository_impl.dart
+++ b/apps/voice_transcriber/lib/features/session/data/repositories/clipboard_repository_impl.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/services.dart';
+
+import '../../domain/repositories/clipboard_repository.dart';
+
+class ClipboardRepositoryImpl implements ClipboardRepository {
+  @override
+  Future<void> copy(String value) {
+    return Clipboard.setData(ClipboardData(text: value));
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/data/repositories/speech_to_text_gateway_impl.dart
+++ b/apps/voice_transcriber/lib/features/session/data/repositories/speech_to_text_gateway_impl.dart
@@ -1,0 +1,46 @@
+import 'package:uuid/uuid.dart';
+
+import '../../domain/entities/audio_recording.dart';
+import '../../domain/entities/transcription_result.dart';
+import '../../domain/repositories/speech_to_text_gateway.dart';
+import '../../domain/repositories/voice_session_settings_repository.dart';
+import '../../domain/value_objects/transcription_engine.dart';
+import '../datasources/fake_local_speech_to_text_datasource.dart';
+import '../datasources/fake_openai_speech_to_text_datasource.dart';
+
+class SpeechToTextGatewayImpl implements SpeechToTextGateway {
+  SpeechToTextGatewayImpl(
+    this._openAiDataSource,
+    this._localDataSource,
+    this._settingsRepository,
+  );
+
+  final FakeOpenAiSpeechToTextDataSource _openAiDataSource;
+  final FakeLocalSpeechToTextDataSource _localDataSource;
+  final VoiceSessionSettingsRepository _settingsRepository;
+  final Uuid _uuid = const Uuid();
+
+  @override
+  Future<TranscriptionResult> transcribe(AudioRecording recording) async {
+    final engine = await _settingsRepository.currentEngine();
+    final text = await _transcribeByEngine(engine, recording);
+    return TranscriptionResult(
+      id: _uuid.v4(),
+      text: text,
+      engineLabel: engine.label,
+      copiedToClipboard: false,
+    );
+  }
+
+  Future<String> _transcribeByEngine(
+    TranscriptionEngine engine,
+    AudioRecording recording,
+  ) {
+    switch (engine) {
+      case TranscriptionEngine.openAi:
+        return _openAiDataSource.transcribe(recording);
+      case TranscriptionEngine.local:
+        return _localDataSource.transcribe(recording);
+    }
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/data/repositories/voice_session_settings_repository_impl.dart
+++ b/apps/voice_transcriber/lib/features/session/data/repositories/voice_session_settings_repository_impl.dart
@@ -1,0 +1,34 @@
+import '../../domain/repositories/voice_session_settings_repository.dart';
+import '../../domain/value_objects/transcription_engine.dart';
+
+class VoiceSessionSettingsRepositoryImpl
+    implements VoiceSessionSettingsRepository {
+  VoiceSessionSettingsRepositoryImpl({
+    bool autoCopyEnabled = true,
+    TranscriptionEngine engine = TranscriptionEngine.openAi,
+  })  : _autoCopyEnabled = autoCopyEnabled,
+        _engine = engine;
+
+  bool _autoCopyEnabled;
+  TranscriptionEngine _engine;
+
+  @override
+  Future<bool> isAutoCopyEnabled() async {
+    return _autoCopyEnabled;
+  }
+
+  @override
+  Future<void> setAutoCopyEnabled(bool value) async {
+    _autoCopyEnabled = value;
+  }
+
+  @override
+  Future<TranscriptionEngine> currentEngine() async {
+    return _engine;
+  }
+
+  @override
+  Future<void> selectEngine(TranscriptionEngine engine) async {
+    _engine = engine;
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/entities/audio_recording.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/entities/audio_recording.dart
@@ -1,0 +1,9 @@
+class AudioRecording {
+  const AudioRecording({
+    required this.bytes,
+    required this.duration,
+  });
+
+  final List<int> bytes;
+  final Duration duration;
+}

--- a/apps/voice_transcriber/lib/features/session/domain/entities/transcription_result.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/entities/transcription_result.dart
@@ -1,0 +1,25 @@
+class TranscriptionResult {
+  const TranscriptionResult({
+    required this.id,
+    required this.text,
+    required this.engineLabel,
+    required this.copiedToClipboard,
+  });
+
+  final String id;
+  final String text;
+  final String engineLabel;
+  final bool copiedToClipboard;
+
+  TranscriptionResult copyWith({
+    String? text,
+    bool? copiedToClipboard,
+  }) {
+    return TranscriptionResult(
+      id: id,
+      text: text ?? this.text,
+      engineLabel: engineLabel,
+      copiedToClipboard: copiedToClipboard ?? this.copiedToClipboard,
+    );
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/entities/voice_session_status.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/entities/voice_session_status.dart
@@ -1,0 +1,7 @@
+enum VoiceSessionStatus {
+  idle,
+  recording,
+  processing,
+  completed,
+  error,
+}

--- a/apps/voice_transcriber/lib/features/session/domain/repositories/audio_recorder_repository.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/repositories/audio_recorder_repository.dart
@@ -1,0 +1,7 @@
+import '../entities/audio_recording.dart';
+
+abstract class AudioRecorderRepository {
+  Future<void> start();
+
+  Future<AudioRecording> stop();
+}

--- a/apps/voice_transcriber/lib/features/session/domain/repositories/clipboard_repository.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/repositories/clipboard_repository.dart
@@ -1,0 +1,3 @@
+abstract class ClipboardRepository {
+  Future<void> copy(String value);
+}

--- a/apps/voice_transcriber/lib/features/session/domain/repositories/speech_to_text_gateway.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/repositories/speech_to_text_gateway.dart
@@ -1,0 +1,6 @@
+import '../entities/audio_recording.dart';
+import '../entities/transcription_result.dart';
+
+abstract class SpeechToTextGateway {
+  Future<TranscriptionResult> transcribe(AudioRecording recording);
+}

--- a/apps/voice_transcriber/lib/features/session/domain/repositories/voice_session_settings_repository.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/repositories/voice_session_settings_repository.dart
@@ -1,0 +1,11 @@
+import '../value_objects/transcription_engine.dart';
+
+abstract class VoiceSessionSettingsRepository {
+  Future<bool> isAutoCopyEnabled();
+
+  Future<void> setAutoCopyEnabled(bool value);
+
+  Future<TranscriptionEngine> currentEngine();
+
+  Future<void> selectEngine(TranscriptionEngine engine);
+}

--- a/apps/voice_transcriber/lib/features/session/domain/usecases/complete_session_use_case.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/usecases/complete_session_use_case.dart
@@ -1,0 +1,33 @@
+import '../entities/transcription_result.dart';
+import '../repositories/audio_recorder_repository.dart';
+import '../repositories/clipboard_repository.dart';
+import '../repositories/speech_to_text_gateway.dart';
+import '../repositories/voice_session_settings_repository.dart';
+
+class CompleteSessionUseCase {
+  CompleteSessionUseCase(
+    this._recorderRepository,
+    this._speechToTextGateway,
+    this._clipboardRepository,
+    this._settingsRepository,
+  );
+
+  final AudioRecorderRepository _recorderRepository;
+  final SpeechToTextGateway _speechToTextGateway;
+  final ClipboardRepository _clipboardRepository;
+  final VoiceSessionSettingsRepository _settingsRepository;
+
+  Future<TranscriptionResult> call() async {
+    final recording = await _recorderRepository.stop();
+    final rawResult = await _speechToTextGateway.transcribe(recording);
+    final shouldCopy = await _settingsRepository.isAutoCopyEnabled();
+
+    if (shouldCopy) {
+      await _clipboardRepository.copy(rawResult.text);
+    }
+
+    return rawResult.copyWith(
+      copiedToClipboard: shouldCopy,
+    );
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/usecases/copy_to_clipboard_use_case.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/usecases/copy_to_clipboard_use_case.dart
@@ -1,0 +1,11 @@
+import '../repositories/clipboard_repository.dart';
+
+class CopyToClipboardUseCase {
+  const CopyToClipboardUseCase(this._clipboardRepository);
+
+  final ClipboardRepository _clipboardRepository;
+
+  Future<void> call(String value) {
+    return _clipboardRepository.copy(value);
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/usecases/load_session_settings_use_case.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/usecases/load_session_settings_use_case.dart
@@ -1,0 +1,24 @@
+import '../repositories/voice_session_settings_repository.dart';
+import '../value_objects/transcription_engine.dart';
+
+class SessionSettingsSnapshot {
+  const SessionSettingsSnapshot({
+    required this.autoCopyEnabled,
+    required this.engine,
+  });
+
+  final bool autoCopyEnabled;
+  final TranscriptionEngine engine;
+}
+
+class LoadSessionSettingsUseCase {
+  const LoadSessionSettingsUseCase(this._settingsRepository);
+
+  final VoiceSessionSettingsRepository _settingsRepository;
+
+  Future<SessionSettingsSnapshot> call() async {
+    final autoCopy = await _settingsRepository.isAutoCopyEnabled();
+    final engine = await _settingsRepository.currentEngine();
+    return SessionSettingsSnapshot(autoCopyEnabled: autoCopy, engine: engine);
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/usecases/select_engine_use_case.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/usecases/select_engine_use_case.dart
@@ -1,0 +1,12 @@
+import '../repositories/voice_session_settings_repository.dart';
+import '../value_objects/transcription_engine.dart';
+
+class SelectEngineUseCase {
+  const SelectEngineUseCase(this._settingsRepository);
+
+  final VoiceSessionSettingsRepository _settingsRepository;
+
+  Future<void> call(TranscriptionEngine engine) {
+    return _settingsRepository.selectEngine(engine);
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/usecases/start_recording_use_case.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/usecases/start_recording_use_case.dart
@@ -1,0 +1,11 @@
+import '../repositories/audio_recorder_repository.dart';
+
+class StartRecordingUseCase {
+  const StartRecordingUseCase(this._recorderRepository);
+
+  final AudioRecorderRepository _recorderRepository;
+
+  Future<void> call() {
+    return _recorderRepository.start();
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/usecases/toggle_auto_copy_use_case.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/usecases/toggle_auto_copy_use_case.dart
@@ -1,0 +1,14 @@
+import '../repositories/voice_session_settings_repository.dart';
+
+class ToggleAutoCopyUseCase {
+  const ToggleAutoCopyUseCase(this._settingsRepository);
+
+  final VoiceSessionSettingsRepository _settingsRepository;
+
+  Future<bool> call() async {
+    final current = await _settingsRepository.isAutoCopyEnabled();
+    final next = !current;
+    await _settingsRepository.setAutoCopyEnabled(next);
+    return next;
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/domain/value_objects/transcription_engine.dart
+++ b/apps/voice_transcriber/lib/features/session/domain/value_objects/transcription_engine.dart
@@ -1,0 +1,15 @@
+enum TranscriptionEngine {
+  openAi,
+  local,
+}
+
+extension TranscriptionEngineLabel on TranscriptionEngine {
+  String get label {
+    switch (this) {
+      case TranscriptionEngine.openAi:
+        return 'OpenAI API';
+      case TranscriptionEngine.local:
+        return 'On-device model';
+    }
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/presentation/cubit/voice_session_cubit.dart
+++ b/apps/voice_transcriber/lib/features/session/presentation/cubit/voice_session_cubit.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/entities/voice_session_status.dart';
+import '../../domain/usecases/complete_session_use_case.dart';
+import '../../domain/usecases/copy_to_clipboard_use_case.dart';
+import '../../domain/usecases/load_session_settings_use_case.dart';
+import '../../domain/usecases/select_engine_use_case.dart';
+import '../../domain/usecases/start_recording_use_case.dart';
+import '../../domain/usecases/toggle_auto_copy_use_case.dart';
+import '../../domain/value_objects/transcription_engine.dart';
+import 'voice_session_state.dart';
+
+class VoiceSessionCubit extends Cubit<VoiceSessionState> {
+  VoiceSessionCubit(
+    super.initialState,
+    this._startRecordingUseCase,
+    this._completeSessionUseCase,
+    this._toggleAutoCopyUseCase,
+    this._loadSessionSettingsUseCase,
+    this._selectEngineUseCase,
+    this._copyToClipboardUseCase,
+  );
+
+  final StartRecordingUseCase _startRecordingUseCase;
+  final CompleteSessionUseCase _completeSessionUseCase;
+  final ToggleAutoCopyUseCase _toggleAutoCopyUseCase;
+  final LoadSessionSettingsUseCase _loadSessionSettingsUseCase;
+  final SelectEngineUseCase _selectEngineUseCase;
+  final CopyToClipboardUseCase _copyToClipboardUseCase;
+
+  Future<void> initialize() async {
+    final snapshot = await _loadSessionSettingsUseCase();
+    emit(
+      state.copyWith(
+        autoCopyEnabled: snapshot.autoCopyEnabled,
+        engine: snapshot.engine,
+      ),
+    );
+  }
+
+  Future<void> startRecording() async {
+    emit(
+      state.copyWith(
+        status: VoiceSessionStatus.recording,
+        errorMessage: null,
+        result: null,
+      ),
+    );
+    try {
+      await _startRecordingUseCase();
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: VoiceSessionStatus.error,
+          errorMessage: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> completeSession() async {
+    emit(
+      state.copyWith(
+        status: VoiceSessionStatus.processing,
+        errorMessage: null,
+      ),
+    );
+
+    try {
+      final result = await _completeSessionUseCase();
+      emit(
+        state.copyWith(
+          status: VoiceSessionStatus.completed,
+          result: result,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: VoiceSessionStatus.error,
+          errorMessage: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> toggleAutoCopy() async {
+    final enabled = await _toggleAutoCopyUseCase();
+    emit(state.copyWith(autoCopyEnabled: enabled));
+  }
+
+  Future<void> selectEngine(TranscriptionEngine engine) async {
+    await _selectEngineUseCase(engine);
+    emit(state.copyWith(engine: engine));
+  }
+
+  void updateTranscription(String text) {
+    final current = state.result;
+    if (current == null) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        result: current.copyWith(text: text),
+      ),
+    );
+  }
+
+  Future<void> copyToClipboard(String text) {
+    return _copyToClipboardUseCase(text);
+  }
+}

--- a/apps/voice_transcriber/lib/features/session/presentation/cubit/voice_session_state.dart
+++ b/apps/voice_transcriber/lib/features/session/presentation/cubit/voice_session_state.dart
@@ -1,0 +1,46 @@
+import 'package:equatable/equatable.dart';
+
+import '../../domain/entities/transcription_result.dart';
+import '../../domain/entities/voice_session_status.dart';
+import '../../domain/value_objects/transcription_engine.dart';
+
+class VoiceSessionState extends Equatable {
+  const VoiceSessionState({
+    this.status = VoiceSessionStatus.idle,
+    this.autoCopyEnabled = true,
+    this.engine = TranscriptionEngine.openAi,
+    this.result,
+    this.errorMessage,
+  });
+
+  final VoiceSessionStatus status;
+  final bool autoCopyEnabled;
+  final TranscriptionEngine engine;
+  final TranscriptionResult? result;
+  final String? errorMessage;
+
+  VoiceSessionState copyWith({
+    VoiceSessionStatus? status,
+    bool? autoCopyEnabled,
+    TranscriptionEngine? engine,
+    TranscriptionResult? result,
+    String? errorMessage,
+  }) {
+    return VoiceSessionState(
+      status: status ?? this.status,
+      autoCopyEnabled: autoCopyEnabled ?? this.autoCopyEnabled,
+      engine: engine ?? this.engine,
+      result: result ?? this.result,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        autoCopyEnabled,
+        engine,
+        result,
+        errorMessage,
+      ];
+}

--- a/apps/voice_transcriber/lib/features/session/presentation/pages/voice_transcriber_page.dart
+++ b/apps/voice_transcriber/lib/features/session/presentation/pages/voice_transcriber_page.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/entities/voice_session_status.dart';
+import '../../domain/value_objects/transcription_engine.dart';
+import '../cubit/voice_session_cubit.dart';
+import '../cubit/voice_session_state.dart';
+
+class VoiceTranscriberPage extends StatefulWidget {
+  const VoiceTranscriberPage({super.key});
+
+  @override
+  State<VoiceTranscriberPage> createState() => _VoiceTranscriberPageState();
+}
+
+class _VoiceTranscriberPageState extends State<VoiceTranscriberPage> {
+  final _textController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<VoiceSessionCubit>().initialize();
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<VoiceSessionCubit, VoiceSessionState>(
+      listener: (context, state) {
+        final result = state.result;
+        if (result != null && _textController.text != result.text) {
+          _textController.text = result.text;
+        }
+
+        if (state.errorMessage != null && state.errorMessage!.isNotEmpty) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('세션 처리 중 오류가 발생했습니다: ${state.errorMessage}'),
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        final cubit = context.read<VoiceSessionCubit>();
+        final isRecording = state.status == VoiceSessionStatus.recording;
+        final isProcessing = state.status == VoiceSessionStatus.processing;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Voice Transcriber'),
+          ),
+          body: SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _SessionStatusBanner(status: state.status),
+                  const SizedBox(height: 16),
+                  _EngineDropdown(
+                    current: state.engine,
+                    onChanged: (engine) {
+                      if (engine != null) {
+                        cubit.selectEngine(engine);
+                      }
+                    },
+                  ),
+                  SwitchListTile.adaptive(
+                    contentPadding: EdgeInsets.zero,
+                    value: state.autoCopyEnabled,
+                    title: const Text('자동 클립보드 복사'),
+                    subtitle: const Text('변환이 완료되면 텍스트를 즉시 클립보드에 복사합니다.'),
+                    onChanged: (_) => cubit.toggleAutoCopy(),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          onPressed: isProcessing
+                              ? null
+                              : () {
+                                  if (isRecording) {
+                                    cubit.completeSession();
+                                  } else {
+                                    cubit.startRecording();
+                                  }
+                                },
+                          icon: Icon(isRecording ? Icons.stop : Icons.mic),
+                          label: Text(isRecording ? '정지 및 변환' : '녹음 시작'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          onPressed: state.result == null
+                              ? null
+                              : () async {
+                                  await cubit.copyToClipboard(_textController.text);
+                                  if (!mounted) return;
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('텍스트를 클립보드에 복사했습니다.'),
+                                    ),
+                                  );
+                                },
+                          icon: const Icon(Icons.copy),
+                          label: const Text('복사하기'),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  if (isProcessing) const LinearProgressIndicator(),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _textController,
+                    minLines: 6,
+                    maxLines: 12,
+                    onChanged: cubit.updateTranscription,
+                    decoration: InputDecoration(
+                      labelText: '변환 결과 미리보기',
+                      alignLabelWithHint: true,
+                      hintText: '변환된 텍스트가 여기에 표시됩니다.',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      _SharingOptionChip(
+                        icon: Icons.share,
+                        label: '공유 옵션',
+                        onTap: state.result == null
+                            ? null
+                            : () {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('외부 공유는 플랫폼 채널에서 구현 예정입니다.'),
+                                  ),
+                                );
+                              },
+                      ),
+                      _SharingOptionChip(
+                        icon: Icons.settings_voice,
+                        label: '음성 명령 등록',
+                        onTap: () {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('디바이스 음성 명령은 Shortcut 통합 단계에서 연동됩니다.'),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  const Text(
+                    '힌트',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text('• “지피티, 이거 물어봐” 명령으로 빠르게 녹음을 시작하세요.'),
+                  const Text('• 디바이스 숏컷을 등록하면 잠금 화면에서도 즉시 실행할 수 있습니다.'),
+                  if (state.result?.engineLabel != null) ...[
+                    const SizedBox(height: 12),
+                    Text('선택된 엔진: ${state.result?.engineLabel ?? state.engine.label}'),
+                    if (state.result?.copiedToClipboard == true)
+                      const Text('결과가 자동으로 클립보드에 복사되었습니다.'),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SessionStatusBanner extends StatelessWidget {
+  const _SessionStatusBanner({
+    required this.status,
+  });
+
+  final VoiceSessionStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final text = () {
+      switch (status) {
+        case VoiceSessionStatus.idle:
+          return '대기 중입니다. 음성 명령이나 버튼으로 녹음을 시작하세요.';
+        case VoiceSessionStatus.recording:
+          return '녹음 중... 말씀이 끝나면 정지 버튼을 눌러 주세요.';
+        case VoiceSessionStatus.processing:
+          return '변환 중입니다. 잠시만 기다려 주세요.';
+        case VoiceSessionStatus.completed:
+          return '변환이 완료되었습니다. 텍스트를 확인하고 공유하거나 편집하세요.';
+        case VoiceSessionStatus.error:
+          return '오류가 발생했습니다. 다시 시도해 주세요.';
+      }
+    }();
+
+    final color = () {
+      switch (status) {
+        case VoiceSessionStatus.recording:
+          return theme.colorScheme.errorContainer;
+        case VoiceSessionStatus.processing:
+          return theme.colorScheme.surfaceVariant;
+        case VoiceSessionStatus.completed:
+          return theme.colorScheme.primaryContainer;
+        case VoiceSessionStatus.error:
+          return theme.colorScheme.errorContainer;
+        case VoiceSessionStatus.idle:
+          return theme.colorScheme.secondaryContainer;
+      }
+    }();
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        text,
+        style: theme.textTheme.bodyMedium,
+      ),
+    );
+  }
+}
+
+class _EngineDropdown extends StatelessWidget {
+  const _EngineDropdown({
+    required this.current,
+    required this.onChanged,
+  });
+
+  final TranscriptionEngine current;
+  final ValueChanged<TranscriptionEngine?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonFormField<TranscriptionEngine>(
+      value: current,
+      decoration: const InputDecoration(
+        labelText: '변환 엔진 선택',
+        border: OutlineInputBorder(),
+      ),
+      items: TranscriptionEngine.values
+          .map(
+            (engine) => DropdownMenuItem<TranscriptionEngine>(
+              value: engine,
+              child: Text(engine.label),
+            ),
+          )
+          .toList(),
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _SharingOptionChip extends StatelessWidget {
+  const _SharingOptionChip({
+    required this.icon,
+    required this.label,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = onTap != null;
+    return InkWell(
+      onTap: enabled ? onTap : null,
+      borderRadius: BorderRadius.circular(24),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: enabled
+              ? Theme.of(context).colorScheme.surfaceVariant
+              : Theme.of(context).disabledColor.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 18),
+            const SizedBox(width: 8),
+            Text(label),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/voice_transcriber/lib/main.dart
+++ b/apps/voice_transcriber/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'voice_transcriber_app.dart';
+
+void main() {
+  runApp(const VoiceTranscriberApp());
+}

--- a/apps/voice_transcriber/lib/voice_transcriber_app.dart
+++ b/apps/voice_transcriber/lib/voice_transcriber_app.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'app/voice_transcriber_dependencies.dart';
+import 'features/session/presentation/cubit/voice_session_cubit.dart';
+import 'features/session/presentation/pages/voice_transcriber_page.dart';
+
+class VoiceTranscriberApp extends StatefulWidget {
+  const VoiceTranscriberApp({super.key});
+
+  @override
+  State<VoiceTranscriberApp> createState() => _VoiceTranscriberAppState();
+}
+
+class _VoiceTranscriberAppState extends State<VoiceTranscriberApp> {
+  late final VoiceTranscriberDependencies _dependencies;
+
+  @override
+  void initState() {
+    super.initState();
+    _dependencies = VoiceTranscriberDependencies.bootstrap();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<VoiceSessionCubit>.value(
+      value: _dependencies.sessionCubit,
+      child: MaterialApp(
+        title: 'Voice Transcriber',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+          useMaterial3: true,
+        ),
+        home: const VoiceTranscriberPage(),
+      ),
+    );
+  }
+}

--- a/apps/voice_transcriber/pubspec.yaml
+++ b/apps/voice_transcriber/pubspec.yaml
@@ -1,0 +1,26 @@
+name: apps.voice_transcriber
+description: Voice transcription assistant service within the SpiralDailyDev mono-repo.
+
+publish_to: 'none'
+
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.0.6 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  flutter_bloc: ^8.1.3
+  equatable: ^2.0.5
+  uuid: ^3.0.7
+
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- introduce the experimental voice_transcriber app following the repo's clean architecture pattern
- add session-centric domain, data, and presentation layers to support audio capture, transcription, and clipboard flows
- document the service architecture and list it in the mono-repo README

## Testing
- not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68df5c618fb4832abde3ca95dd81512b