### PR TITLE
feat: add map provider abstractions and integrate into spiral map

### DIFF
--- a/apps/spiral_map/lib/main.dart
+++ b/apps/spiral_map/lib/main.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:map_provider_core/map_provider_core.dart';
+
+import 'providers/google_map_provider.dart';
+import 'providers/template_placeholder_provider.dart';
 
 void main() {
-  runApp(SpiralDeliveryMapApp());
+  runApp(const SpiralDeliveryMapApp());
 }
 
 class SpiralDeliveryMapApp extends StatelessWidget {
+  const SpiralDeliveryMapApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
       debugShowCheckedModeBanner: false,
-      title: 'DeliveryMap',
+      title: 'Spiral Delivery Map',
       home: SpiralDeliveryMap(),
     );
   }
@@ -24,20 +29,170 @@ class SpiralDeliveryMap extends StatefulWidget {
 }
 
 class _SpiralDeliveryMapState extends State<SpiralDeliveryMap> {
-  static const LatLng _kMapCenter =
-  LatLng(19.018255973653343, 72.84793849278007);
+  late final MapProviderRegistry _registry;
+  late String _selectedProviderId;
 
-  static const CameraPosition _kInitialPosition =
-  CameraPosition(target: _kMapCenter, zoom: 11.0, tilt: 0, bearing: 0);
+  MapMarker? _lastTappedMarker;
+  GeoCoordinate? _lastTappedCoordinate;
+  MapCameraPosition? _lastCameraPosition;
+
+  MapViewConfiguration get _configuration {
+    return MapViewConfiguration(
+      initialCameraPosition: const MapCameraPosition(
+        target: GeoCoordinate(19.018255973653343, 72.84793849278007),
+        zoom: 11,
+      ),
+      markers: {
+        MapMarker(
+          id: 'spiral-hq',
+          position: const GeoCoordinate(19.018255973653343, 72.84793849278007),
+          infoWindow: const MapMarkerInfoWindow(
+            title: 'Spiral HQ',
+            snippet: 'Central Operations Hub',
+          ),
+          style: const MapMarkerStyle(hue: 210),
+          onTap: () => debugPrint('Spiral HQ marker tapped'),
+        ),
+        MapMarker(
+          id: 'delivery-yard',
+          position: const GeoCoordinate(19.07283, 72.88261),
+          infoWindow: const MapMarkerInfoWindow(
+            title: 'Delivery Yard',
+            snippet: 'Primary sorting location',
+          ),
+          style: const MapMarkerStyle(hue: 35),
+        ),
+      },
+      onMarkerTap: (marker) => setState(() => _lastTappedMarker = marker),
+      onMapTap: (coordinate) =>
+          setState(() => _lastTappedCoordinate = coordinate),
+      onCameraMove: (position) => _lastCameraPosition = position,
+      onCameraIdle: (position) =>
+          setState(() => _lastCameraPosition = position),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _registry = MapProviderRegistry()
+      ..register(GoogleMapProvider())
+      ..register(const TemplatePlaceholderProvider());
+    final providers = _registry.providers;
+    _selectedProviderId =
+        providers.isNotEmpty ? providers.first.id : 'template_placeholder';
+  }
 
   @override
   Widget build(BuildContext context) {
+    final provider = _registry.resolve(_selectedProviderId);
+
     return Scaffold(
       appBar: AppBar(
-        title: Text('Google Maps Demo'),
+        title: const Text('Spiral Map Providers'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: _selectedProviderId,
+                onChanged: (value) {
+                  if (value == null) {
+                    return;
+                  }
+                  setState(() => _selectedProviderId = value);
+                },
+                items: _registry.providers
+                    .map(
+                      (provider) => DropdownMenuItem<String>(
+                        value: provider.id,
+                        child: Text(provider.displayName),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          ),
+        ],
       ),
-      body: GoogleMap(
-        initialCameraPosition: _kInitialPosition,
+      body: provider == null
+          ? const Center(child: Text('No map providers registered.'))
+          : Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: provider.buildMap(context, _configuration),
+                    ),
+                  ),
+                ),
+                _StatusPanel(
+                  lastTappedMarker: _lastTappedMarker,
+                  lastTappedCoordinate: _lastTappedCoordinate,
+                  lastCameraPosition: _lastCameraPosition,
+                  selectedProvider: provider.displayName,
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _StatusPanel extends StatelessWidget {
+  const _StatusPanel({
+    required this.lastTappedMarker,
+    required this.lastTappedCoordinate,
+    required this.lastCameraPosition,
+    required this.selectedProvider,
+  });
+
+  final MapMarker? lastTappedMarker;
+  final GeoCoordinate? lastTappedCoordinate;
+  final MapCameraPosition? lastCameraPosition;
+  final String selectedProvider;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant,
+        border: Border(
+          top: BorderSide(color: Theme.of(context).dividerColor),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('Active provider: $selectedProvider'),
+          const SizedBox(height: 8),
+          Text(
+            lastCameraPosition == null
+                ? 'Camera idle at initial position'
+                : 'Camera @ '
+                    '${lastCameraPosition!.target.latitude.toStringAsFixed(4)}, '
+                    '${lastCameraPosition!.target.longitude.toStringAsFixed(4)} '
+                    '(zoom: ${lastCameraPosition!.zoom.toStringAsFixed(1)})',
+          ),
+          const SizedBox(height: 8),
+          Text(
+            lastTappedCoordinate == null
+                ? 'Tap on the map to capture coordinates.'
+                : 'Last tap @ '
+                    '${lastTappedCoordinate!.latitude.toStringAsFixed(4)}, '
+                    '${lastTappedCoordinate!.longitude.toStringAsFixed(4)}',
+          ),
+          const SizedBox(height: 8),
+          Text(
+            lastTappedMarker == null
+                ? 'Tap a marker to see selection updates.'
+                : 'Last marker tapped: ${lastTappedMarker!.id}',
+          ),
+        ],
       ),
     );
   }

--- a/apps/spiral_map/lib/providers/google_map_provider.dart
+++ b/apps/spiral_map/lib/providers/google_map_provider.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:map_provider_core/map_provider_core.dart';
+
+class GoogleMapProvider extends MapProviderAdapter {
+  GoogleMapProvider();
+
+  CameraPosition? _lastKnownCameraPosition;
+
+  @override
+  String get id => 'google_maps';
+
+  @override
+  String get displayName => 'Google Maps';
+
+  @override
+  Widget buildMap(BuildContext context, MapViewConfiguration configuration) {
+    return GoogleMap(
+      initialCameraPosition:
+          _toCameraPosition(configuration.initialCameraPosition),
+      markers: configuration.markers
+          .map((marker) => _toGoogleMarker(marker, configuration))
+          .toSet(),
+      onTap: (position) =>
+          configuration.onMapTap?.call(_toGeoCoordinate(position)),
+      onCameraMove: (position) {
+        _lastKnownCameraPosition = position;
+        configuration.onCameraMove?.call(_toMapCameraPosition(position));
+      },
+      onCameraIdle: () {
+        final camera = _lastKnownCameraPosition;
+        if (camera != null) {
+          configuration.onCameraIdle?.call(_toMapCameraPosition(camera));
+        }
+      },
+    );
+  }
+
+  @override
+  bool supportsMarkerStyle(MapMarkerStyle style) {
+    // The Google Maps Flutter plugin supports marker tinting via hue. Asset
+    // based icons require asynchronous loading which is not handled in this
+    // adapter template.
+    return style.assetName == null;
+  }
+
+  Marker _toGoogleMarker(
+    MapMarker marker,
+    MapViewConfiguration configuration,
+  ) {
+    return Marker(
+      markerId: MarkerId(marker.id),
+      position: LatLng(marker.position.latitude, marker.position.longitude),
+      icon: marker.style.hue != null
+          ? BitmapDescriptor.defaultMarkerWithHue(marker.style.hue!)
+          : BitmapDescriptor.defaultMarker,
+      infoWindow: marker.infoWindow == null
+          ? InfoWindow.noText
+          : InfoWindow(
+              title: marker.infoWindow!.title,
+              snippet: marker.infoWindow!.snippet,
+            ),
+      onTap: () {
+        marker.onTap?.call();
+        configuration.onMarkerTap?.call(marker);
+      },
+    );
+  }
+
+  CameraPosition _toCameraPosition(MapCameraPosition position) {
+    return CameraPosition(
+      target: LatLng(position.target.latitude, position.target.longitude),
+      zoom: position.zoom,
+      tilt: position.tilt,
+      bearing: position.bearing,
+    );
+  }
+
+  MapCameraPosition _toMapCameraPosition(CameraPosition position) {
+    return MapCameraPosition(
+      target: GeoCoordinate(position.target.latitude, position.target.longitude),
+      zoom: position.zoom,
+      tilt: position.tilt,
+      bearing: position.bearing,
+    );
+  }
+
+  GeoCoordinate _toGeoCoordinate(LatLng position) {
+    return GeoCoordinate(position.latitude, position.longitude);
+  }
+}

--- a/apps/spiral_map/lib/providers/template_placeholder_provider.dart
+++ b/apps/spiral_map/lib/providers/template_placeholder_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:map_provider_core/map_provider_core.dart';
+
+/// Example provider built on top of [MapProviderTemplate].
+class TemplatePlaceholderProvider extends MapProviderTemplate {
+  const TemplatePlaceholderProvider();
+
+  @override
+  String get id => 'template_placeholder';
+
+  @override
+  String get displayName => 'Custom Provider Template';
+
+  @override
+  Widget buildPlaceholder(
+    BuildContext context,
+    MapViewConfiguration configuration,
+  ) {
+    return super.buildPlaceholder(context, configuration);
+  }
+}

--- a/apps/spiral_map/pubspec.yaml
+++ b/apps/spiral_map/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
+  map_provider_core:
+    path: ../../packages/map_provider_core
   google_maps_flutter: ^2.0.1
 
 dev_dependencies:

--- a/packages/map_provider_core/analysis_options.yaml
+++ b/packages/map_provider_core/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true

--- a/packages/map_provider_core/lib/map_provider_core.dart
+++ b/packages/map_provider_core/lib/map_provider_core.dart
@@ -1,0 +1,9 @@
+library map_provider_core;
+
+export 'src/geo_coordinate.dart';
+export 'src/map_camera_position.dart';
+export 'src/map_marker.dart';
+export 'src/map_provider_adapter.dart';
+export 'src/map_provider_registry.dart';
+export 'src/map_view_configuration.dart';
+export 'src/map_provider_template.dart';

--- a/packages/map_provider_core/lib/src/geo_coordinate.dart
+++ b/packages/map_provider_core/lib/src/geo_coordinate.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+/// Represents a geographic coordinate using latitude and longitude values.
+@immutable
+class GeoCoordinate {
+  const GeoCoordinate(this.latitude, this.longitude)
+      : assert(latitude >= -90 && latitude <= 90,
+            'Latitude must be between -90 and 90 degrees.'),
+        assert(longitude >= -180 && longitude <= 180,
+            'Longitude must be between -180 and 180 degrees.');
+
+  /// Latitude component in degrees.
+  final double latitude;
+
+  /// Longitude component in degrees.
+  final double longitude;
+
+  /// Creates a copy of the coordinate with modified values.
+  GeoCoordinate copyWith({double? latitude, double? longitude}) {
+    return GeoCoordinate(latitude ?? this.latitude, longitude ?? this.longitude);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is GeoCoordinate &&
+        other.latitude == latitude &&
+        other.longitude == longitude;
+  }
+
+  @override
+  int get hashCode => Object.hash(latitude, longitude);
+
+  @override
+  String toString() => 'GeoCoordinate(lat: $latitude, lng: $longitude)';
+}

--- a/packages/map_provider_core/lib/src/map_camera_position.dart
+++ b/packages/map_provider_core/lib/src/map_camera_position.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+
+import 'geo_coordinate.dart';
+
+/// Represents the camera configuration for a map view.
+@immutable
+class MapCameraPosition {
+  const MapCameraPosition({
+    required this.target,
+    this.zoom = 14,
+    this.tilt = 0,
+    this.bearing = 0,
+  });
+
+  /// The geographical target the camera is pointing to.
+  final GeoCoordinate target;
+
+  /// The zoom level of the camera.
+  final double zoom;
+
+  /// The camera's tilt angle in degrees.
+  final double tilt;
+
+  /// The camera's bearing in degrees measured clockwise from north.
+  final double bearing;
+
+  /// Creates a copy with selective overrides.
+  MapCameraPosition copyWith({
+    GeoCoordinate? target,
+    double? zoom,
+    double? tilt,
+    double? bearing,
+  }) {
+    return MapCameraPosition(
+      target: target ?? this.target,
+      zoom: zoom ?? this.zoom,
+      tilt: tilt ?? this.tilt,
+      bearing: bearing ?? this.bearing,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(target, zoom, tilt, bearing);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is MapCameraPosition &&
+        other.target == target &&
+        other.zoom == zoom &&
+        other.tilt == tilt &&
+        other.bearing == bearing;
+  }
+
+  @override
+  String toString() {
+    return 'MapCameraPosition(target: $target, zoom: $zoom, tilt: $tilt, bearing: $bearing)';
+  }
+}

--- a/packages/map_provider_core/lib/src/map_marker.dart
+++ b/packages/map_provider_core/lib/src/map_marker.dart
@@ -1,0 +1,90 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+import 'geo_coordinate.dart';
+
+/// Describes how a marker should be rendered on top of the map.
+@immutable
+class MapMarkerStyle {
+  const MapMarkerStyle({
+    this.assetName,
+    this.assetPackage,
+    this.width,
+    this.height,
+    this.tintColor,
+    this.hue,
+  });
+
+  /// Asset name that should be used as the marker icon.
+  final String? assetName;
+
+  /// The package containing the asset when [assetName] is provided.
+  final String? assetPackage;
+
+  /// Desired width of the marker icon in logical pixels.
+  final double? width;
+
+  /// Desired height of the marker icon in logical pixels.
+  final double? height;
+
+  /// Tint color to apply to the marker icon if supported by the provider.
+  final Color? tintColor;
+
+  /// Convenience hue value for providers that support simple hue-based colors.
+  final double? hue;
+
+  MapMarkerStyle copyWith({
+    String? assetName,
+    String? assetPackage,
+    double? width,
+    double? height,
+    Color? tintColor,
+    double? hue,
+  }) {
+    return MapMarkerStyle(
+      assetName: assetName ?? this.assetName,
+      assetPackage: assetPackage ?? this.assetPackage,
+      width: width ?? this.width,
+      height: height ?? this.height,
+      tintColor: tintColor ?? this.tintColor,
+      hue: hue ?? this.hue,
+    );
+  }
+}
+
+/// Metadata shown when interacting with a marker.
+@immutable
+class MapMarkerInfoWindow {
+  const MapMarkerInfoWindow({this.title, this.snippet});
+
+  final String? title;
+  final String? snippet;
+}
+
+/// Represents an interactive marker placed on a map view.
+@immutable
+class MapMarker {
+  const MapMarker({
+    required this.id,
+    required this.position,
+    this.style = const MapMarkerStyle(),
+    this.infoWindow,
+    this.onTap,
+  });
+
+  /// Unique identifier for the marker within a map view.
+  final String id;
+
+  /// Geographic coordinate of the marker.
+  final GeoCoordinate position;
+
+  /// Styling information for the marker.
+  final MapMarkerStyle style;
+
+  /// Optional info window metadata that should be displayed on tap.
+  final MapMarkerInfoWindow? infoWindow;
+
+  /// Callback invoked when the marker is tapped.
+  final VoidCallback? onTap;
+}

--- a/packages/map_provider_core/lib/src/map_provider_adapter.dart
+++ b/packages/map_provider_core/lib/src/map_provider_adapter.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import 'map_marker.dart';
+import 'map_view_configuration.dart';
+
+/// Base contract that every map provider implementation must fulfil.
+abstract class MapProviderAdapter {
+  const MapProviderAdapter();
+
+  /// Unique identifier for the provider.
+  String get id;
+
+  /// Human readable name used in selection UIs.
+  String get displayName;
+
+  /// Builds the map widget using the supplied configuration.
+  Widget buildMap(BuildContext context, MapViewConfiguration configuration);
+
+  /// Returns whether the provider supports rendering markers styled with [style].
+  bool supportsMarkerStyle(MapMarkerStyle style);
+}

--- a/packages/map_provider_core/lib/src/map_provider_registry.dart
+++ b/packages/map_provider_core/lib/src/map_provider_registry.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+
+import 'map_provider_adapter.dart';
+
+/// Registry used to manage map provider implementations at runtime.
+class MapProviderRegistry {
+  MapProviderRegistry();
+
+  final Map<String, MapProviderAdapter> _providers = <String, MapProviderAdapter>{};
+
+  /// Registers a provider. When a provider with the same [id] already exists
+  /// it will be replaced by the new instance.
+  void register(MapProviderAdapter provider) {
+    _providers[provider.id] = provider;
+  }
+
+  /// Removes a provider by identifier.
+  void unregister(String id) {
+    _providers.remove(id);
+  }
+
+  /// Returns the provider matching the supplied [id] or `null` if none is
+  /// registered for that identifier.
+  MapProviderAdapter? resolve(String id) => _providers[id];
+
+  /// All registered providers sorted by their display names for a stable UI.
+  List<MapProviderAdapter> get providers {
+    final items = _providers.values.toList(growable: false);
+    items.sort((a, b) => compareAsciiLowerCase(a.displayName, b.displayName));
+    return items;
+  }
+
+  /// True when at least one provider has been registered.
+  bool get hasProviders => _providers.isNotEmpty;
+}

--- a/packages/map_provider_core/lib/src/map_provider_template.dart
+++ b/packages/map_provider_core/lib/src/map_provider_template.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'map_marker.dart';
+import 'map_provider_adapter.dart';
+import 'map_view_configuration.dart';
+
+/// Template that can be extended by teams implementing a new provider.
+///
+/// The default implementation renders a placeholder widget to highlight where
+/// the actual map should appear. Extending classes are expected to override
+/// [buildPlaceholder] or [buildMap] to hook in their own provider specific
+/// widgets.
+abstract class MapProviderTemplate extends MapProviderAdapter {
+  const MapProviderTemplate();
+
+  @override
+  Widget buildMap(BuildContext context, MapViewConfiguration configuration) {
+    return buildPlaceholder(context, configuration);
+  }
+
+  /// Override this method to render provider specific widgets.
+  @protected
+  Widget buildPlaceholder(
+    BuildContext context,
+    MapViewConfiguration configuration,
+  ) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Theme.of(context).colorScheme.outline),
+        color: Theme.of(context).colorScheme.surfaceVariant,
+      ),
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.map_outlined,
+                  color: Theme.of(context).colorScheme.primary, size: 48),
+              const SizedBox(height: 16),
+              Text(
+                'Implement the $displayName provider by overriding buildMap.',
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool supportsMarkerStyle(MapMarkerStyle style) => true;
+}

--- a/packages/map_provider_core/lib/src/map_view_configuration.dart
+++ b/packages/map_provider_core/lib/src/map_view_configuration.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/foundation.dart';
+
+import 'geo_coordinate.dart';
+import 'map_camera_position.dart';
+import 'map_marker.dart';
+
+/// Represents the data required for rendering a map view regardless of the
+/// underlying provider implementation.
+@immutable
+class MapViewConfiguration {
+  const MapViewConfiguration({
+    required this.initialCameraPosition,
+    this.markers = const <MapMarker>{},
+    this.onMarkerTap,
+    this.onMapTap,
+    this.onCameraIdle,
+    this.onCameraMove,
+  });
+
+  /// Initial camera configuration when the map is first rendered.
+  final MapCameraPosition initialCameraPosition;
+
+  /// Markers that should be displayed on the map.
+  final Set<MapMarker> markers;
+
+  /// Callback invoked when a marker has been tapped. Providers should prefer
+  /// delegating marker tap handling to the marker itself, but this acts as a
+  /// global fallback to keep APIs consistent across implementations.
+  final ValueChanged<MapMarker>? onMarkerTap;
+
+  /// Callback invoked when the map surface is tapped by the user.
+  final ValueChanged<GeoCoordinate>? onMapTap;
+
+  /// Callback invoked when the camera stops moving.
+  final ValueChanged<MapCameraPosition>? onCameraIdle;
+
+  /// Callback invoked whenever the camera moves.
+  final ValueChanged<MapCameraPosition>? onCameraMove;
+
+  MapViewConfiguration copyWith({
+    MapCameraPosition? initialCameraPosition,
+    Set<MapMarker>? markers,
+    ValueChanged<MapMarker>? onMarkerTap,
+    ValueChanged<GeoCoordinate>? onMapTap,
+    ValueChanged<MapCameraPosition>? onCameraIdle,
+    ValueChanged<MapCameraPosition>? onCameraMove,
+  }) {
+    return MapViewConfiguration(
+      initialCameraPosition:
+          initialCameraPosition ?? this.initialCameraPosition,
+      markers: markers ?? this.markers,
+      onMarkerTap: onMarkerTap ?? this.onMarkerTap,
+      onMapTap: onMapTap ?? this.onMapTap,
+      onCameraIdle: onCameraIdle ?? this.onCameraIdle,
+      onCameraMove: onCameraMove ?? this.onCameraMove,
+    );
+  }
+}

--- a/packages/map_provider_core/pubspec.yaml
+++ b/packages/map_provider_core/pubspec.yaml
@@ -1,0 +1,19 @@
+name: map_provider_core
+description: Core abstractions and templates for Spiral map providers.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add the `map_provider_core` shared package with runtime provider, marker, and camera abstractions plus an onboarding template
- refactor the `spiral_map` app to consume the shared interfaces and surface runtime provider selection with status feedback
- implement a Google Maps provider adapter and include a template placeholder provider for future integrations

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8c2a509f8832a9ae15f87b2e46bbc