### PR TITLE
Add map switcher service with provider templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Flutter 기반의 Mono Repo 베이스, Clean Architecture 룰을 따르는 프�
 | Exchange Rate Calculator | 환율 조회 및 계산 기능을 제공하는 학습용 앱 | 싱글톤 저장소가 외부 API에서 환율 정보를 가져오고 Adapter 패턴으로 다양한 데이터 소스를 통합하며 GoRouter 기반 라우팅을 제공합니다. |
 | Spiral Trade Show | 서울시 전시 정보를 보여주는 홍보용 앱 | Dio HTTP 클라이언트와 보안 키를 활용해 공공 데이터 포털에서 전시 정보를 수집하고 Cubit 패턴으로 UI 상태를 갱신합니다. |
 | Voice Transcriber | 음성 녹음과 텍스트 변환을 지원하는 실험용 앱 | Clean Architecture 기반의 세션 단위 UseCase 설계를 통해 A/B 테스트용 변환 엔진(OpenAI vs 자체 모델)을 런타임에서 전환하고 자동 클립보드 복사를 제공합니다. |
+| Map Switcher | 다양한 지도 제공자를 런타임에 전환하는 지도 온보딩 앱 | 공통 MapProvider 인터페이스와 DetailCard 마커 커스터마이저를 활용해 Google/Naver/Amazon 템플릿을 제공하고 GoRouter 기반 라우팅을 공유합니다. |
 
 ## Daily Memo App
 - `sqflite`를 사용하는 `SQLHelper`를 통해 로컬 데이터베이스에 메모를 저장하고 CRUD 기능을 제공합니다.

--- a/apps/map_switcher/README.md
+++ b/apps/map_switcher/README.md
@@ -1,0 +1,3 @@
+# Map Switcher
+
+Shared map experience demonstrating runtime provider swapping within the SpiralDailyDev mono-repository.

--- a/apps/map_switcher/analysis_options.yaml
+++ b/apps/map_switcher/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - lib/**.g.dart
+    - lib/firebase_options.dart
+    - pubspec.yaml
+
+linter:
+  rules:

--- a/apps/map_switcher/lib/app/map_switcher_dependencies.dart
+++ b/apps/map_switcher/lib/app/map_switcher_dependencies.dart
@@ -1,0 +1,157 @@
+import 'package:app_navigation/app_navigation.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ui_components/ui_components.dart';
+import 'package:utils/utils.dart';
+
+import '../features/dashboard/presentation/pages/map_dashboard_page.dart';
+import '../features/providers/presentation/pages/provider_catalog_page.dart';
+
+enum MapSwitcherRoute {
+  home('/'),
+  providers('/providers');
+
+  const MapSwitcherRoute(this.path);
+  final String path;
+}
+
+class MapSwitcherDependencies {
+  MapSwitcherDependencies._({
+    required this.registry,
+    required this.routesController,
+    required this.markerCustomizer,
+    required this.router,
+    required this.markers,
+  });
+
+  static Future<MapSwitcherDependencies> bootstrap() async {
+    final registry = MapProviderRegistry(
+      providers: const [
+        GoogleMapsProviderTemplate(),
+        NaverMapsProviderTemplate(),
+        AmazonLocationProviderTemplate(),
+      ],
+    );
+    await registry.initializeActive();
+
+    final routesController = GoRouterRoutesController(
+      navigationType: GoRouterNavigationType.path,
+      popAllStrategy: GoRouterPopAllStrategy.navigate,
+    );
+
+    final markerCustomizer = DetailCardMarkerCustomizer();
+    final markers = _buildSampleMarkers();
+
+    late final GoRouter router;
+
+    router = GoRouter(
+      initialLocation: MapSwitcherRoute.home.path,
+      routes: [
+        GoRoute(
+          path: MapSwitcherRoute.home.path,
+          builder: (context, state) => MapDashboardPage(
+            registry: registry,
+            markers: markers,
+            markerCustomizer: markerCustomizer,
+            routesController: routesController,
+          ),
+        ),
+        GoRoute(
+          path: MapSwitcherRoute.providers.path,
+          builder: (context, state) => ProviderCatalogPage(
+            registry: registry,
+            routesController: routesController,
+            markerCustomizer: markerCustomizer,
+          ),
+        ),
+      ],
+    );
+
+    return MapSwitcherDependencies._(
+      registry: registry,
+      routesController: routesController,
+      markerCustomizer: markerCustomizer,
+      router: router,
+      markers: markers,
+    );
+  }
+
+  final MapProviderRegistry registry;
+  final RoutesController routesController;
+  final MapMarkerCustomizer markerCustomizer;
+  final GoRouter router;
+  final List<MapMarker> markers;
+}
+
+class DetailCardMarkerCustomizer implements MapMarkerCustomizer {
+  @override
+  Widget buildMarker(BuildContext context, MapMarker marker) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.location_on, color: colorScheme.primary),
+        const SizedBox(height: 4),
+        Text(
+          marker.info?.title ?? marker.id,
+          style: Theme.of(context).textTheme.labelMedium,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget buildMarkerDetail(BuildContext context, MapMarker marker) {
+    final info = marker.info;
+    if (info == null) {
+      return Text('마커 ${marker.id}');
+    }
+
+    return DetailCard(
+      sectionTitle: info.place,
+      primaryColor: Theme.of(context).colorScheme.primaryContainer,
+      info: info,
+    );
+  }
+}
+
+List<MapMarker> _buildSampleMarkers() {
+  return [
+    MapMarker(
+      id: 'seoul-city-hall',
+      position: const MapCoordinate(latitude: 37.5665, longitude: 126.9780),
+      info: Info(
+        '서울특별시청',
+        'https://images.unsplash.com/photo-1549692520-acc6669e2f0c?auto=format&fit=crop&w=400&q=80',
+        '서울 중구 세종대로 110',
+        '서울의 역사와 현재가 공존하는 대표적인 시민 소통 공간입니다.',
+        DateTime(2024, 1, 1),
+        DateTime(2024, 12, 31),
+      ),
+    ),
+    MapMarker(
+      id: 'han-river-park',
+      position: const MapCoordinate(latitude: 37.5286, longitude: 126.9326),
+      info: Info(
+        '한강공원',
+        'https://images.unsplash.com/photo-1526481280695-3c4692dcaaf9?auto=format&fit=crop&w=400&q=80',
+        '서울 영등포구 여의동로 330',
+        '도심 속에서 레저와 휴식을 동시에 즐길 수 있는 대표 수변공원입니다.',
+        DateTime(2024, 3, 1),
+        DateTime(2024, 11, 30),
+      ),
+    ),
+    MapMarker(
+      id: 'namdaemun-market',
+      position: const MapCoordinate(latitude: 37.5593, longitude: 126.9770),
+      info: Info(
+        '남대문시장',
+        'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=400&q=80',
+        '서울 중구 남창동 49-1',
+        '조선시대부터 이어져 온 국내 최대 규모의 전통 시장입니다.',
+        DateTime(2024, 1, 1),
+        DateTime(2024, 12, 31),
+      ),
+    ),
+  ];
+}

--- a/apps/map_switcher/lib/features/dashboard/presentation/pages/map_dashboard_page.dart
+++ b/apps/map_switcher/lib/features/dashboard/presentation/pages/map_dashboard_page.dart
@@ -1,0 +1,113 @@
+import 'package:app_navigation/app_navigation.dart';
+import 'package:flutter/material.dart';
+import 'package:utils/utils.dart';
+
+import '../../../../app/map_switcher_dependencies.dart';
+
+class MapDashboardPage extends StatelessWidget {
+  const MapDashboardPage({
+    super.key,
+    required this.registry,
+    required this.markers,
+    required this.markerCustomizer,
+    required this.routesController,
+  });
+
+  final MapProviderRegistry registry;
+  final List<MapMarker> markers;
+  final MapMarkerCustomizer markerCustomizer;
+  final RoutesController routesController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('지도 제공자 스위처'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.map_outlined),
+            tooltip: '제공자 목록 보기',
+            onPressed: () => routesController.navigateTo(
+              context,
+              MapSwitcherRoute.providers.path,
+            ),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: AnimatedBuilder(
+          animation: registry,
+          builder: (context, _) {
+            final providers = registry.availableProviders;
+            final activeType = registry.activeType;
+            final activeProvider = registry.activeProvider;
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Wrap(
+                  spacing: 16,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    const Text(
+                      '현재 사용 중인 지도',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    DropdownButton<MapProviderType>(
+                      value: activeType,
+                      items: [
+                        for (final provider in providers)
+                          DropdownMenuItem<MapProviderType>(
+                            value: provider.type,
+                            child: Text(provider.displayName),
+                          ),
+                      ],
+                      onChanged: (value) async {
+                        if (value == null) return;
+                        await registry.switchTo(value);
+                      },
+                    ),
+                    FilledButton.icon(
+                      onPressed: () => routesController.navigateTo(
+                        context,
+                        MapSwitcherRoute.providers.path,
+                      ),
+                      icon: const Icon(Icons.list_alt),
+                      label: const Text('제공자 둘러보기'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Expanded(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.surface,
+                      borderRadius: BorderRadius.circular(24),
+                      border: Border.all(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .outlineVariant,
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: activeProvider.buildMap(
+                        MapViewRequest(
+                          context: context,
+                          markers: markers,
+                          markerCustomizer: markerCustomizer,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/apps/map_switcher/lib/features/providers/presentation/pages/provider_catalog_page.dart
+++ b/apps/map_switcher/lib/features/providers/presentation/pages/provider_catalog_page.dart
@@ -1,0 +1,74 @@
+import 'package:app_navigation/app_navigation.dart';
+import 'package:flutter/material.dart';
+import 'package:ui_components/ui_components.dart';
+import 'package:utils/utils.dart';
+
+class ProviderCatalogPage extends StatelessWidget {
+  const ProviderCatalogPage({
+    super.key,
+    required this.registry,
+    required this.routesController,
+    required this.markerCustomizer,
+  });
+
+  final MapProviderRegistry registry;
+  final RoutesController routesController;
+  final MapMarkerCustomizer markerCustomizer;
+
+  @override
+  Widget build(BuildContext context) {
+    final providers = registry.availableProviders;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('지도 제공자 카탈로그'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '활성화된 마커 커스터마이저: ${markerCustomizer.runtimeType}',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.separated(
+                itemBuilder: (context, index) {
+                  final provider = providers[index];
+                  final hint = provider is TemplateMapProvider
+                      ? provider.integrationHint
+                      : '이 제공자에 맞게 초기화를 구성하세요.';
+                  return MapProviderPreview(
+                    title: provider.displayName,
+                    description: hint,
+                    accentColor: _accentColor(provider.type, Theme.of(context)),
+                    onTap: () async {
+                      await registry.switchTo(provider.type);
+                      if (context.mounted) {
+                        routesController.pop(context);
+                      }
+                    },
+                  );
+                },
+                separatorBuilder: (context, index) => const SizedBox(height: 16),
+                itemCount: providers.length,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _accentColor(MapProviderType type, ThemeData theme) {
+    switch (type) {
+      case MapProviderType.google:
+        return Colors.indigo;
+      case MapProviderType.naver:
+        return Colors.green;
+      case MapProviderType.amazon:
+        return theme.colorScheme.secondary;
+    }
+  }
+}

--- a/apps/map_switcher/lib/main.dart
+++ b/apps/map_switcher/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'map_switcher_app.dart';
+
+void main() {
+  runApp(const MapSwitcherApp());
+}

--- a/apps/map_switcher/lib/map_switcher_app.dart
+++ b/apps/map_switcher/lib/map_switcher_app.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import 'app/map_switcher_dependencies.dart';
+
+class MapSwitcherApp extends StatefulWidget {
+  const MapSwitcherApp({super.key});
+
+  @override
+  State<MapSwitcherApp> createState() => _MapSwitcherAppState();
+}
+
+class _MapSwitcherAppState extends State<MapSwitcherApp> {
+  MapSwitcherDependencies? _dependencies;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDependencies();
+  }
+
+  Future<void> _loadDependencies() async {
+    final dependencies = await MapSwitcherDependencies.bootstrap();
+    if (!mounted) return;
+    setState(() => _dependencies = dependencies);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dependencies = _dependencies;
+
+    if (dependencies == null) {
+      return MaterialApp(
+        title: 'Map Switcher',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+          useMaterial3: true,
+        ),
+        home: const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    return MaterialApp.router(
+      title: 'Map Switcher',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+        useMaterial3: true,
+      ),
+      routerConfig: dependencies.router,
+    );
+  }
+}

--- a/apps/map_switcher/pubspec.yaml
+++ b/apps/map_switcher/pubspec.yaml
@@ -1,0 +1,29 @@
+name: apps.map_switcher
+description: Multi-provider map experience leveraging shared SpiralDailyDev infrastructure.
+
+publish_to: 'none'
+
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.0.6 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  go_router: ^12.1.1
+  app_navigation:
+    path: ../../packages/app_navigation
+  ui_components:
+    path: ../../packages/ui_components
+  utils:
+    path: ../../packages/utils
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true

--- a/packages/ui_components/lib/map/map_provider_preview.dart
+++ b/packages/ui_components/lib/map/map_provider_preview.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+/// Lightweight card that describes a map provider.
+class MapProviderPreview extends StatelessWidget {
+  const MapProviderPreview({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.accentColor,
+    this.onTap,
+  });
+
+  final String title;
+  final String description;
+  final Color accentColor;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        gradient: LinearGradient(
+          colors: [accentColor.withOpacity(0.9), accentColor.withOpacity(0.5)],
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            description,
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: Colors.white.withOpacity(0.95)),
+          ),
+        ],
+      ),
+    );
+
+    if (onTap == null) {
+      return card;
+    }
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: onTap,
+      child: card,
+    );
+  }
+}

--- a/packages/ui_components/lib/ui_components.dart
+++ b/packages/ui_components/lib/ui_components.dart
@@ -1,7 +1,8 @@
 library ui_components;
 
-/// A Calculator.
-class Calculator {
-  /// Returns [value] plus 1.
-  int addOne(int value) => value + 1;
-}
+export 'card/detail_card.dart';
+export 'card/horizon_card.dart';
+export 'card/info.dart';
+export 'card/tab_card.dart';
+export 'card/time_tab_card.dart';
+export 'map/map_provider_preview.dart';

--- a/packages/ui_components/test/ui_components_test.dart
+++ b/packages/ui_components/test/ui_components_test.dart
@@ -1,12 +1,26 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:ui_components/ui_components.dart';
 
 void main() {
-  test('adds one to input values', () {
-    final calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
+  testWidgets('MapProviderPreview invokes callback when tapped', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MapProviderPreview(
+            title: 'Google Maps',
+            description: 'Preview widget',
+            accentColor: Colors.blue,
+            onTap: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(MapProviderPreview));
+    await tester.pumpAndSettle();
+
+    expect(tapped, isTrue);
   });
 }

--- a/packages/utils/lib/maps/map_marker.dart
+++ b/packages/utils/lib/maps/map_marker.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:ui_components/card/info.dart';
+
+/// Represents a point of interest that should be rendered on a map.
+class MapMarker {
+  const MapMarker({
+    required this.id,
+    required this.position,
+    this.info,
+    this.icon,
+  });
+
+  /// Unique identifier used by providers to track marker state.
+  final String id;
+
+  /// Geographical position of the marker.
+  final MapCoordinate position;
+
+  /// Optional rich information associated with the marker.
+  ///
+  /// The structure mirrors [Info] from `ui_components` so map services can
+  /// easily reuse existing card templates when showing marker details.
+  final Info? info;
+
+  /// Optional icon override for providers that support custom widgets.
+  final Widget? icon;
+}
+
+/// Immutable latitude/longitude pair.
+class MapCoordinate {
+  const MapCoordinate({
+    required this.latitude,
+    required this.longitude,
+  });
+
+  final double latitude;
+  final double longitude;
+}

--- a/packages/utils/lib/maps/map_marker_customizer.dart
+++ b/packages/utils/lib/maps/map_marker_customizer.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/widgets.dart';
+
+import 'map_marker.dart';
+
+/// Contract for building visual representations of markers across providers.
+abstract interface class MapMarkerCustomizer {
+  /// Builds the widget that should be used as the marker glyph on the map.
+  Widget buildMarker(BuildContext context, MapMarker marker);
+
+  /// Builds an optional detailed representation for the marker.
+  ///
+  /// Providers can surface this widget inside an info window, bottom sheet or
+  /// any other container that matches the UX of the underlying SDK.
+  Widget buildMarkerDetail(BuildContext context, MapMarker marker);
+}

--- a/packages/utils/lib/maps/map_provider.dart
+++ b/packages/utils/lib/maps/map_provider.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+
+import 'map_marker.dart';
+import 'map_marker_customizer.dart';
+
+/// Supported provider identifiers.
+enum MapProviderType { google, naver, amazon }
+
+/// Parameters required to render a map.
+class MapViewRequest {
+  const MapViewRequest({
+    required this.context,
+    required this.markers,
+    required this.markerCustomizer,
+  });
+
+  final BuildContext context;
+  final List<MapMarker> markers;
+  final MapMarkerCustomizer markerCustomizer;
+}
+
+/// Base contract for all map provider implementations.
+abstract interface class MapProvider {
+  MapProviderType get type;
+  String get displayName;
+
+  /// Allows the provider to perform async initialization.
+  Future<void> initialize();
+
+  /// Builds the map widget for the current provider.
+  Widget buildMap(MapViewRequest request);
+}
+
+/// Simple placeholder used by the template implementations.
+class MapProviderPlaceholder extends StatelessWidget {
+  const MapProviderPlaceholder({
+    super.key,
+    required this.providerName,
+    required this.markers,
+    required this.markerCustomizer,
+    required this.description,
+  });
+
+  final String providerName;
+  final List<MapMarker> markers;
+  final MapMarkerCustomizer markerCustomizer;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          providerName,
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: markers.isEmpty
+              ? const Center(
+                  child: Text('표시할 마커가 없습니다. 마커 설정을 추가하세요.'),
+                )
+              : ListView.separated(
+                  itemBuilder: (context, index) {
+                    final marker = markers[index];
+                    return DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.surfaceVariant,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            markerCustomizer.buildMarker(context, marker),
+                            const SizedBox(width: 16),
+                            Expanded(
+                              child: markerCustomizer
+                                  .buildMarkerDetail(context, marker),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                  separatorBuilder: (context, index) => const SizedBox(height: 12),
+                  itemCount: markers.length,
+                ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          description,
+          style: Theme.of(context)
+              .textTheme
+              .bodySmall
+              ?.copyWith(fontStyle: FontStyle.italic),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/utils/lib/maps/map_provider_registry.dart
+++ b/packages/utils/lib/maps/map_provider_registry.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+
+import 'map_provider.dart';
+
+/// Simple registry that keeps track of available map providers and the active
+/// selection.
+class MapProviderRegistry extends ChangeNotifier {
+  MapProviderRegistry({
+    required List<MapProvider> providers,
+    MapProviderType? initialType,
+  }) : _providers = {
+          for (final provider in providers) provider.type: provider,
+        } {
+    if (_providers.isEmpty) {
+      throw ArgumentError('At least one map provider must be registered.');
+    }
+    _activeType = initialType ?? providers.first.type;
+  }
+
+  final Map<MapProviderType, MapProvider> _providers;
+  late MapProviderType _activeType;
+  bool _initialized = false;
+
+  MapProvider get activeProvider => _providers[_activeType]!;
+  MapProviderType get activeType => _activeType;
+  List<MapProvider> get availableProviders =>
+      List.unmodifiable(_providers.values);
+
+  Future<void> initializeActive() async {
+    if (_initialized) return;
+    await activeProvider.initialize();
+    _initialized = true;
+  }
+
+  Future<void> switchTo(MapProviderType type) async {
+    if (type == _activeType) return;
+    final provider = _providers[type];
+    if (provider == null) {
+      throw ArgumentError('Provider $type is not registered.');
+    }
+    await provider.initialize();
+    _activeType = type;
+    _initialized = true;
+    notifyListeners();
+  }
+
+  void register(MapProvider provider) {
+    _providers[provider.type] = provider;
+    notifyListeners();
+  }
+}

--- a/packages/utils/lib/maps/map_provider_templates.dart
+++ b/packages/utils/lib/maps/map_provider_templates.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import 'map_provider.dart';
+
+abstract class TemplateMapProvider implements MapProvider {
+  const TemplateMapProvider({required this.type, required this.displayName});
+
+  @override
+  final MapProviderType type;
+
+  @override
+  final String displayName;
+
+  @override
+  Future<void> initialize() async {}
+
+  String get integrationHint;
+
+  @override
+  Widget buildMap(MapViewRequest request) {
+    return MapProviderPlaceholder(
+      providerName: displayName,
+      markers: request.markers,
+      markerCustomizer: request.markerCustomizer,
+      description: integrationHint,
+    );
+  }
+}
+
+class GoogleMapsProviderTemplate extends TemplateMapProvider {
+  const GoogleMapsProviderTemplate()
+      : super(
+          type: MapProviderType.google,
+          displayName: 'Google Maps',
+        );
+
+  @override
+  String get integrationHint =>
+      'TODO: Google Maps SDK 연동 후 실제 지도를 표시하세요.';
+}
+
+class NaverMapsProviderTemplate extends TemplateMapProvider {
+  const NaverMapsProviderTemplate()
+      : super(
+          type: MapProviderType.naver,
+          displayName: 'Naver Map',
+        );
+
+  @override
+  String get integrationHint =>
+      'TODO: 네이버 지도 SDK 연동 및 인증 키 설정이 필요합니다.';
+}
+
+class AmazonLocationProviderTemplate extends TemplateMapProvider {
+  const AmazonLocationProviderTemplate()
+      : super(
+          type: MapProviderType.amazon,
+          displayName: 'Amazon Location Service',
+        );
+
+  @override
+  String get integrationHint =>
+      'TODO: Amazon Location Service 지도를 구성하고 권한을 연결하세요.';
+}

--- a/packages/utils/lib/utils.dart
+++ b/packages/utils/lib/utils.dart
@@ -1,7 +1,7 @@
 library utils;
 
-/// A Calculator.
-class Calculator {
-  /// Returns [value] plus 1.
-  int addOne(int value) => value + 1;
-}
+export 'maps/map_marker.dart';
+export 'maps/map_marker_customizer.dart';
+export 'maps/map_provider.dart';
+export 'maps/map_provider_registry.dart';
+export 'maps/map_provider_templates.dart';

--- a/packages/utils/test/utils_test.dart
+++ b/packages/utils/test/utils_test.dart
@@ -1,12 +1,53 @@
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:utils/utils.dart';
 
+class _FakeProvider extends TemplateMapProvider {
+  _FakeProvider({
+    required MapProviderType type,
+    required this.name,
+  }) : super(type: type, displayName: name);
+
+  final String name;
+  int initializeCount = 0;
+
+  @override
+  Future<void> initialize() async {
+    initializeCount++;
+  }
+
+  @override
+  String get integrationHint => 'Fake provider for testing';
+}
+
 void main() {
-  test('adds one to input values', () {
-    final calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
+  test('registry initializes the default provider once', () async {
+    final provider = _FakeProvider(
+      type: MapProviderType.google,
+      name: 'fake-google',
+    );
+    final registry = MapProviderRegistry(providers: [provider]);
+
+    await registry.initializeActive();
+    await registry.initializeActive();
+
+    expect(provider.initializeCount, 1);
+    expect(registry.activeProvider, provider);
+  });
+
+  test('switching provider triggers initialization and notifies listeners', () async {
+    final google = _FakeProvider(type: MapProviderType.google, name: 'google');
+    final naver = _FakeProvider(type: MapProviderType.naver, name: 'naver');
+    final registry = MapProviderRegistry(providers: [google, naver]);
+    await registry.initializeActive();
+
+    var notified = false;
+    registry.addListener(() => notified = true);
+
+    await registry.switchTo(MapProviderType.naver);
+
+    expect(notified, isTrue);
+    expect(registry.activeProvider, naver);
+    expect(google.initializeCount, 1);
+    expect(naver.initializeCount, 1);
   });
 }


### PR DESCRIPTION
## Summary
- define reusable map provider interfaces, registry, and template implementations in the shared utils package
- add a map provider preview component and widget test to the shared ui_components package
- create the map_switcher Flutter app that reuses the mono-repo router, utilities, and UI components to swap Google/Naver/Amazon providers at runtime

## Testing
- Not run (flutter pub get)

------
https://chatgpt.com/codex/tasks/task_e_68e8ca9acb14832a954977effce8c4ca