### PR TITLE
feat: migrate map switcher to interactive map platform

### DIFF
--- a/apps/map_switcher/README.md
+++ b/apps/map_switcher/README.md
@@ -1,3 +1,9 @@
 # Map Switcher
 
 Shared map experience demonstrating runtime provider swapping within the SpiralDailyDev mono-repository.
+
+## Highlights
+
+- Interactive OpenStreetMap implementation with panning, zooming, and marker overlays.
+- Provider registry architecture that allows runtime switching between real SDK integrations and placeholder templates.
+- Searchable location catalog with quick navigation controls that drive the active map provider.

--- a/apps/map_switcher/lib/app/map_switcher_dependencies.dart
+++ b/apps/map_switcher/lib/app/map_switcher_dependencies.dart
@@ -5,6 +5,7 @@ import 'package:ui_components/ui_components.dart';
 import 'package:utils/utils.dart';
 
 import '../features/dashboard/presentation/pages/map_dashboard_page.dart';
+import '../features/map/providers/open_street_map_provider.dart';
 import '../features/providers/presentation/pages/provider_catalog_page.dart';
 
 enum MapSwitcherRoute {
@@ -26,10 +27,11 @@ class MapSwitcherDependencies {
 
   static Future<MapSwitcherDependencies> bootstrap() async {
     final registry = MapProviderRegistry(
-      providers: const [
-        GoogleMapsProviderTemplate(),
-        NaverMapsProviderTemplate(),
-        AmazonLocationProviderTemplate(),
+      providers: [
+        OpenStreetMapProvider(),
+        const GoogleMapsProviderTemplate(),
+        const NaverMapsProviderTemplate(),
+        const AmazonLocationProviderTemplate(),
       ],
     );
     await registry.initializeActive();

--- a/apps/map_switcher/lib/features/dashboard/presentation/pages/map_dashboard_page.dart
+++ b/apps/map_switcher/lib/features/dashboard/presentation/pages/map_dashboard_page.dart
@@ -1,10 +1,12 @@
+import 'dart:async';
+
 import 'package:app_navigation/app_navigation.dart';
 import 'package:flutter/material.dart';
 import 'package:utils/utils.dart';
 
 import '../../../../app/map_switcher_dependencies.dart';
 
-class MapDashboardPage extends StatelessWidget {
+class MapDashboardPage extends StatefulWidget {
   const MapDashboardPage({
     super.key,
     required this.registry,
@@ -19,7 +21,65 @@ class MapDashboardPage extends StatelessWidget {
   final RoutesController routesController;
 
   @override
+  State<MapDashboardPage> createState() => _MapDashboardPageState();
+}
+
+class _MapDashboardPageState extends State<MapDashboardPage> {
+  MapProviderController? _controller;
+  MapMarker? _selectedMarker;
+  String _searchQuery = '';
+
+  List<MapMarker> get _filteredMarkers {
+    final query = _searchQuery.trim().toLowerCase();
+    if (query.isEmpty) {
+      return widget.markers;
+    }
+    return widget.markers.where((marker) {
+      final values = <String?>[
+        marker.id,
+        marker.info?.title,
+        marker.info?.place,
+        marker.info?.description,
+      ];
+      return values.any(
+        (value) => value != null && value.toLowerCase().contains(query),
+      );
+    }).toList();
+  }
+
+  Future<void> _moveToMarker(MapMarker marker) async {
+    final controller = _controller;
+    if (controller == null) {
+      return;
+    }
+    unawaited(controller.highlightMarker(marker.id));
+    await controller.moveTo(marker.position, zoom: 15);
+  }
+
+  Future<void> _fitToAllMarkers() async {
+    final controller = _controller;
+    if (controller == null) {
+      return;
+    }
+    await controller.fitBounds(widget.markers);
+  }
+
+  void _handleControllerReady(MapProviderController controller) {
+    setState(() {
+      _controller = controller;
+    });
+  }
+
+  void _handleMarkerSelected(MapMarker? marker) {
+    setState(() {
+      _selectedMarker = marker;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final registry = widget.registry;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('지도 제공자 스위처'),
@@ -27,7 +87,7 @@ class MapDashboardPage extends StatelessWidget {
           IconButton(
             icon: const Icon(Icons.map_outlined),
             tooltip: '제공자 목록 보기',
-            onPressed: () => routesController.navigateTo(
+            onPressed: () => widget.routesController.navigateTo(
               context,
               MapSwitcherRoute.providers.path,
             ),
@@ -41,64 +101,57 @@ class MapDashboardPage extends StatelessWidget {
           builder: (context, _) {
             final providers = registry.availableProviders;
             final activeType = registry.activeType;
-            final activeProvider = registry.activeProvider;
 
-            return Column(
+            return Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Wrap(
-                  spacing: 16,
-                  runSpacing: 8,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    const Text(
-                      '현재 사용 중인 지도',
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                SizedBox(
+                  width: 360,
+                  child: _NavigationPanel(
+                    providers: providers,
+                    activeType: activeType,
+                    onProviderSelected: (type) => registry.switchTo(type),
+                    onBrowseProviders: () => widget.routesController.navigateTo(
+                      context,
+                      MapSwitcherRoute.providers.path,
                     ),
-                    DropdownButton<MapProviderType>(
-                      value: activeType,
-                      items: [
-                        for (final provider in providers)
-                          DropdownMenuItem<MapProviderType>(
-                            value: provider.type,
-                            child: Text(provider.displayName),
-                          ),
-                      ],
-                      onChanged: (value) async {
-                        if (value == null) return;
-                        await registry.switchTo(value);
-                      },
-                    ),
-                    FilledButton.icon(
-                      onPressed: () => routesController.navigateTo(
-                        context,
-                        MapSwitcherRoute.providers.path,
-                      ),
-                      icon: const Icon(Icons.list_alt),
-                      label: const Text('제공자 둘러보기'),
-                    ),
-                  ],
+                    markers: _filteredMarkers,
+                    markerCustomizer: widget.markerCustomizer,
+                    selectedMarker: _selectedMarker,
+                    onMarkerTap: _moveToMarker,
+                    onSearchChanged: (value) => setState(() {
+                      _searchQuery = value;
+                    }),
+                    onClearSelection: () {
+                      final controller = _controller;
+                      if (controller != null) {
+                        controller.highlightMarker('');
+                      }
+                      setState(() => _selectedMarker = null);
+                    },
+                    onFitAllMarkers: _fitToAllMarkers,
+                    isFiltering: _searchQuery.trim().isNotEmpty,
+                  ),
                 ),
-                const SizedBox(height: 24),
+                const SizedBox(width: 24),
                 Expanded(
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       color: Theme.of(context).colorScheme.surface,
                       borderRadius: BorderRadius.circular(24),
                       border: Border.all(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .outlineVariant,
+                        color:
+                            Theme.of(context).colorScheme.outlineVariant,
                       ),
                     ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: activeProvider.buildMap(
-                        MapViewRequest(
-                          context: context,
-                          markers: markers,
-                          markerCustomizer: markerCustomizer,
-                        ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: _MapViewport(
+                        registry: registry,
+                        markers: widget.markers,
+                        markerCustomizer: widget.markerCustomizer,
+                        onControllerReady: _handleControllerReady,
+                        onMarkerSelected: _handleMarkerSelected,
                       ),
                     ),
                   ),
@@ -108,6 +161,349 @@ class MapDashboardPage extends StatelessWidget {
           },
         ),
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _fitToAllMarkers,
+        icon: const Icon(Icons.center_focus_strong),
+        label: const Text('전체 영역 보기'),
+      ),
     );
+  }
+}
+
+class _NavigationPanel extends StatelessWidget {
+  const _NavigationPanel({
+    required this.providers,
+    required this.activeType,
+    required this.onProviderSelected,
+    required this.onBrowseProviders,
+    required this.markers,
+    required this.markerCustomizer,
+    required this.selectedMarker,
+    required this.onMarkerTap,
+    required this.onSearchChanged,
+    required this.onClearSelection,
+    required this.onFitAllMarkers,
+    required this.isFiltering,
+  });
+
+  final List<MapProvider> providers;
+  final MapProviderType activeType;
+  final ValueChanged<MapProviderType> onProviderSelected;
+  final VoidCallback onBrowseProviders;
+  final List<MapMarker> markers;
+  final MapMarkerCustomizer markerCustomizer;
+  final MapMarker? selectedMarker;
+  final ValueChanged<MapMarker> onMarkerTap;
+  final ValueChanged<String> onSearchChanged;
+  final VoidCallback onClearSelection;
+  final Future<void> Function() onFitAllMarkers;
+  final bool isFiltering;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outlineVariant,
+        ),
+      ),
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '지도 제어',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<MapProviderType>(
+            value: activeType,
+            decoration: const InputDecoration(
+              labelText: '활성 지도 제공자',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              for (final provider in providers)
+                DropdownMenuItem(
+                  value: provider.type,
+                  child: Text(provider.displayName),
+                ),
+            ],
+            onChanged: (value) {
+              if (value != null) {
+                onProviderSelected(value);
+              }
+            },
+          ),
+          const SizedBox(height: 12),
+          FilledButton.icon(
+            onPressed: onBrowseProviders,
+            icon: const Icon(Icons.list_alt),
+            label: const Text('제공자 둘러보기'),
+          ),
+          const Divider(height: 32),
+          Text(
+            '위치 탐색',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            decoration: const InputDecoration(
+              prefixIcon: Icon(Icons.search),
+              labelText: '지점 이름, 설명, 주소 검색',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: onSearchChanged,
+          ),
+          const SizedBox(height: 12),
+          FilledButton.icon(
+            onPressed: onFitAllMarkers,
+            icon: const Icon(Icons.zoom_out_map),
+            label: const Text('모든 지점 보기'),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: markers.isEmpty
+                ? Center(
+                    child: Text(
+                      isFiltering
+                          ? '검색 결과가 없습니다.'
+                          : '등록된 위치가 없습니다.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  )
+                : SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        for (final marker in markers)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 12),
+                            child: _MarkerListTile(
+                              marker: marker,
+                              markerCustomizer: markerCustomizer,
+                              onTap: () => onMarkerTap(marker),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+          ),
+          if (selectedMarker != null) ...[
+            const Divider(height: 32),
+            Row(
+              children: [
+                Text(
+                  '선택된 위치',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const Spacer(),
+                IconButton(
+                  tooltip: '선택 해제',
+                  onPressed: onClearSelection,
+                  icon: const Icon(Icons.close),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 220,
+              child: SingleChildScrollView(
+                child:
+                    markerCustomizer.buildMarkerDetail(context, selectedMarker!),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MarkerListTile extends StatelessWidget {
+  const _MarkerListTile({
+    required this.marker,
+    required this.markerCustomizer,
+    required this.onTap,
+  });
+
+  final MapMarker marker;
+  final MapMarkerCustomizer markerCustomizer;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceVariant,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              markerCustomizer.buildMarker(context, marker),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      marker.info?.title ?? marker.id,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    if (marker.info?.place != null) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        marker.info!.place,
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ],
+                    if (marker.info?.description != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        marker.info!.description,
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodySmall
+                            ?.copyWith(color: Colors.black87),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MapViewport extends StatefulWidget {
+  const _MapViewport({
+    required this.registry,
+    required this.markers,
+    required this.markerCustomizer,
+    this.onControllerReady,
+    this.onMarkerSelected,
+  });
+
+  final MapProviderRegistry registry;
+  final List<MapMarker> markers;
+  final MapMarkerCustomizer markerCustomizer;
+  final ValueChanged<MapProviderController>? onControllerReady;
+  final ValueChanged<MapMarker?>? onMarkerSelected;
+
+  @override
+  State<_MapViewport> createState() => _MapViewportState();
+}
+
+class _MapViewportState extends State<_MapViewport> {
+  MapProviderType? _activeType;
+  MapProviderView? _view;
+  VoidCallback? _selectionListener;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _buildView();
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _MapViewport oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final activeType = widget.registry.activeType;
+    if (_activeType != activeType) {
+      _buildView();
+    } else {
+      final controller = _view?.controller;
+      if (controller != null) {
+        controller.setMarkers(widget.markers);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _detachSelectionListener();
+    _view?.controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _buildView() async {
+    _detachSelectionListener();
+    _view?.controller.dispose();
+
+    final provider = widget.registry.activeProvider;
+    final view = provider.buildView(
+      MapViewRequest(
+        context: context,
+        markers: widget.markers,
+        markerCustomizer: widget.markerCustomizer,
+        initialCenter: widget.markers.isNotEmpty
+            ? widget.markers.first.position
+            : null,
+        initialZoom: 13,
+      ),
+    );
+    await view.controller.setMarkers(widget.markers);
+
+    if (!mounted) {
+      view.controller.dispose();
+      return;
+    }
+
+    setState(() {
+      _view = view;
+      _activeType = provider.type;
+    });
+
+    widget.onControllerReady?.call(view.controller);
+    _attachSelectionListener(view.controller);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _view?.controller != view.controller) {
+        return;
+      }
+      unawaited(view.controller.fitBounds(widget.markers));
+    });
+  }
+
+  void _attachSelectionListener(MapProviderController controller) {
+    _selectionListener = () {
+      widget.onMarkerSelected?.call(controller.selectedMarker.value);
+    };
+    controller.selectedMarker.addListener(_selectionListener!);
+    widget.onMarkerSelected?.call(controller.selectedMarker.value);
+  }
+
+  void _detachSelectionListener() {
+    final listener = _selectionListener;
+    final controller = _view?.controller;
+    if (listener != null && controller != null) {
+      controller.selectedMarker.removeListener(listener);
+    }
+    _selectionListener = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final view = _view;
+    if (view == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return view.map;
   }
 }

--- a/apps/map_switcher/lib/features/map/providers/open_street_map_provider.dart
+++ b/apps/map_switcher/lib/features/map/providers/open_street_map_provider.dart
@@ -1,0 +1,234 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:utils/utils.dart';
+
+class OpenStreetMapProvider implements MapProvider {
+  OpenStreetMapProvider()
+      : _controller = MapController(),
+        _markers = ValueNotifier<List<MapMarker>>(<MapMarker>[]),
+        _selectedMarker = ValueNotifier<MapMarker?>(null);
+
+  final MapController _controller;
+  final ValueNotifier<List<MapMarker>> _markers;
+  final ValueNotifier<MapMarker?> _selectedMarker;
+
+  @override
+  MapProviderType get type => MapProviderType.openStreetMap;
+
+  @override
+  String get displayName => 'OpenStreetMap';
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  MapProviderView buildView(MapViewRequest request) {
+    return MapProviderView(
+      map: _OpenStreetMapView(
+        controller: _controller,
+        markers: _markers,
+        selectedMarker: _selectedMarker,
+        request: request,
+      ),
+      controller: _OpenStreetMapController(
+        mapController: _controller,
+        markers: _markers,
+        selectedMarker: _selectedMarker,
+      ),
+    );
+  }
+}
+
+class _OpenStreetMapController implements MapProviderController {
+  _OpenStreetMapController({
+    required MapController mapController,
+    required ValueNotifier<List<MapMarker>> markers,
+    required ValueNotifier<MapMarker?> selectedMarker,
+  })  : _mapController = mapController,
+        _markers = markers,
+        _selectedMarker = selectedMarker;
+
+  final MapController _mapController;
+  final ValueNotifier<List<MapMarker>> _markers;
+  final ValueNotifier<MapMarker?> _selectedMarker;
+
+  @override
+  ValueNotifier<MapMarker?> get selectedMarker => _selectedMarker;
+
+  @override
+  Future<void> moveTo(MapCoordinate position, {double? zoom}) async {
+    final point = LatLng(position.latitude, position.longitude);
+    final targetZoom = zoom ?? _mapController.zoom;
+    _mapController.move(point, targetZoom);
+  }
+
+  @override
+  Future<void> setMarkers(List<MapMarker> markers) async {
+    _markers.value = List<MapMarker>.unmodifiable(markers);
+  }
+
+  @override
+  Future<void> highlightMarker(String markerId) async {
+    if (markerId.isEmpty) {
+      _selectedMarker.value = null;
+      return;
+    }
+    _selectedMarker.value =
+        _markers.value.firstWhereOrNull((marker) => marker.id == markerId);
+  }
+
+  @override
+  Future<void> fitBounds(List<MapMarker> markers) async {
+    if (markers.isEmpty) {
+      return;
+    }
+    if (markers.length == 1) {
+      await moveTo(markers.first.position, zoom: 14);
+      return;
+    }
+    final bounds = LatLngBounds.fromPoints(
+      markers
+          .map((marker) => LatLng(
+                marker.position.latitude,
+                marker.position.longitude,
+              ))
+          .toList(),
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _mapController.fitBounds(
+        bounds,
+        options: const FitBoundsOptions(padding: EdgeInsets.all(48)),
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _markers.dispose();
+    _selectedMarker.dispose();
+  }
+}
+
+class _OpenStreetMapView extends StatefulWidget {
+  const _OpenStreetMapView({
+    required this.controller,
+    required this.markers,
+    required this.selectedMarker,
+    required this.request,
+  });
+
+  final MapController controller;
+  final ValueNotifier<List<MapMarker>> markers;
+  final ValueNotifier<MapMarker?> selectedMarker;
+  final MapViewRequest request;
+
+  @override
+  State<_OpenStreetMapView> createState() => _OpenStreetMapViewState();
+}
+
+class _OpenStreetMapViewState extends State<_OpenStreetMapView> {
+  late final MapController _controller = widget.controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final initialPosition = widget.request.initialCenter ??
+        (widget.markers.value.isNotEmpty
+            ? widget.markers.value.first.position
+            : const MapCoordinate(latitude: 37.5665, longitude: 126.9780));
+    final initialZoom = widget.request.initialZoom ?? 12.0;
+
+    return Stack(
+      children: [
+        ValueListenableBuilder<List<MapMarker>>(
+          valueListenable: widget.markers,
+          builder: (context, markers, _) {
+            return FlutterMap(
+              mapController: _controller,
+              options: MapOptions(
+                initialCenter: LatLng(
+                  initialPosition.latitude,
+                  initialPosition.longitude,
+                ),
+                initialZoom: initialZoom,
+                interactionOptions: const InteractionOptions(
+                  flags: InteractiveFlag.all,
+                ),
+                onTap: (_, __) => widget.selectedMarker.value = null,
+              ),
+              children: [
+                TileLayer(
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  userAgentPackageName: 'com.spiraldev.map_switcher',
+                  retinaMode: true,
+                ),
+                MarkerLayer(
+                  markers: [
+                    for (final marker in markers)
+                      Marker(
+                        point: LatLng(
+                          marker.position.latitude,
+                          marker.position.longitude,
+                        ),
+                        width: 120,
+                        height: 120,
+                        builder: (context) => GestureDetector(
+                          onTap: () => widget.selectedMarker.value = marker,
+                          child: marker.icon ??
+                              widget.request.markerCustomizer
+                                  .buildMarker(context, marker),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            );
+          },
+        ),
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 16,
+          child: ValueListenableBuilder<MapMarker?>(
+            valueListenable: widget.selectedMarker,
+            builder: (context, marker, _) {
+              if (marker == null) {
+                return const SizedBox.shrink();
+              }
+              return DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      blurRadius: 12,
+                      color: Colors.black.withOpacity(0.2),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: widget.request.markerCustomizer
+                      .buildMarkerDetail(context, marker),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+extension on Iterable<MapMarker> {
+  MapMarker? firstWhereOrNull(bool Function(MapMarker marker) predicate) {
+    for (final marker in this) {
+      if (predicate(marker)) {
+        return marker;
+      }
+    }
+    return null;
+  }
+}

--- a/apps/map_switcher/lib/features/providers/presentation/pages/provider_catalog_page.dart
+++ b/apps/map_switcher/lib/features/providers/presentation/pages/provider_catalog_page.dart
@@ -63,6 +63,8 @@ class ProviderCatalogPage extends StatelessWidget {
 
   Color _accentColor(MapProviderType type, ThemeData theme) {
     switch (type) {
+      case MapProviderType.openStreetMap:
+        return Colors.orange;
       case MapProviderType.google:
         return Colors.indigo;
       case MapProviderType.naver:

--- a/apps/map_switcher/pubspec.yaml
+++ b/apps/map_switcher/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
     path: ../../packages/ui_components
   utils:
     path: ../../packages/utils
+  flutter_map: ^5.1.0
+  latlong2: ^0.9.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/utils/lib/maps/map_provider.dart
+++ b/packages/utils/lib/maps/map_provider.dart
@@ -4,7 +4,7 @@ import 'map_marker.dart';
 import 'map_marker_customizer.dart';
 
 /// Supported provider identifiers.
-enum MapProviderType { google, naver, amazon }
+enum MapProviderType { google, naver, amazon, openStreetMap }
 
 /// Parameters required to render a map.
 class MapViewRequest {
@@ -12,11 +12,50 @@ class MapViewRequest {
     required this.context,
     required this.markers,
     required this.markerCustomizer,
+    this.initialCenter,
+    this.initialZoom,
   });
 
   final BuildContext context;
   final List<MapMarker> markers;
   final MapMarkerCustomizer markerCustomizer;
+  final MapCoordinate? initialCenter;
+  final double? initialZoom;
+}
+
+/// Bridge that exposes imperative operations for the rendered map.
+abstract interface class MapProviderController {
+  /// Notifies listeners when the user selects or focuses on a marker.
+  ValueNotifier<MapMarker?> get selectedMarker;
+
+  /// Moves the visible camera to the provided [position].
+  Future<void> moveTo(
+    MapCoordinate position, {
+    double? zoom,
+  });
+
+  /// Replaces the markers currently rendered on the map.
+  Future<void> setMarkers(List<MapMarker> markers);
+
+  /// Asks the map to highlight the marker matching the provided [markerId].
+  Future<void> highlightMarker(String markerId);
+
+  /// Adjusts the camera so that all [markers] become visible.
+  Future<void> fitBounds(List<MapMarker> markers);
+
+  /// Cleans up resources when the controller is no longer required.
+  void dispose();
+}
+
+/// Combination of the rendered map widget and its controller.
+class MapProviderView {
+  const MapProviderView({
+    required this.map,
+    required this.controller,
+  });
+
+  final Widget map;
+  final MapProviderController controller;
 }
 
 /// Base contract for all map provider implementations.
@@ -27,8 +66,8 @@ abstract interface class MapProvider {
   /// Allows the provider to perform async initialization.
   Future<void> initialize();
 
-  /// Builds the map widget for the current provider.
-  Widget buildMap(MapViewRequest request);
+  /// Builds the map widget and supporting controller for the provider.
+  MapProviderView buildView(MapViewRequest request);
 }
 
 /// Simple placeholder used by the template implementations.
@@ -36,68 +75,78 @@ class MapProviderPlaceholder extends StatelessWidget {
   const MapProviderPlaceholder({
     super.key,
     required this.providerName,
-    required this.markers,
+    required this.markersListenable,
     required this.markerCustomizer,
     required this.description,
   });
 
   final String providerName;
-  final List<MapMarker> markers;
+  final ValueListenable<List<MapMarker>> markersListenable;
   final MapMarkerCustomizer markerCustomizer;
   final String description;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(
-          providerName,
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
-        const SizedBox(height: 16),
-        Expanded(
-          child: markers.isEmpty
-              ? const Center(
-                  child: Text('표시할 마커가 없습니다. 마커 설정을 추가하세요.'),
-                )
-              : ListView.separated(
-                  itemBuilder: (context, index) {
-                    final marker = markers[index];
-                    return DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surfaceVariant,
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            markerCustomizer.buildMarker(context, marker),
-                            const SizedBox(width: 16),
-                            Expanded(
-                              child: markerCustomizer
-                                  .buildMarkerDetail(context, marker),
+    return ValueListenableBuilder<List<MapMarker>>(
+      valueListenable: markersListenable,
+      builder: (context, markers, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              providerName,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: markers.isEmpty
+                  ? const Center(
+                      child: Text('표시할 마커가 없습니다. 마커 설정을 추가하세요.'),
+                    )
+                  : ListView.separated(
+                      itemBuilder: (context, index) {
+                        final marker = markers[index];
+                        return DecoratedBox(
+                          decoration: BoxDecoration(
+                            color:
+                                Theme.of(context).colorScheme.surfaceVariant,
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                markerCustomizer.buildMarker(
+                                  context,
+                                  marker,
+                                ),
+                                const SizedBox(width: 16),
+                                Expanded(
+                                  child: markerCustomizer
+                                      .buildMarkerDetail(context, marker),
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
-                  separatorBuilder: (context, index) => const SizedBox(height: 12),
-                  itemCount: markers.length,
-                ),
-        ),
-        const SizedBox(height: 16),
-        Text(
-          description,
-          style: Theme.of(context)
-              .textTheme
-              .bodySmall
-              ?.copyWith(fontStyle: FontStyle.italic),
-        ),
-      ],
+                          ),
+                        );
+                      },
+                      separatorBuilder: (context, index) =>
+                          const SizedBox(height: 12),
+                      itemCount: markers.length,
+                    ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              description,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(fontStyle: FontStyle.italic),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/packages/utils/lib/maps/map_provider_templates.dart
+++ b/packages/utils/lib/maps/map_provider_templates.dart
@@ -1,6 +1,54 @@
 import 'package:flutter/material.dart';
 
+import 'map_marker.dart';
 import 'map_provider.dart';
+
+class _TemplateMapProviderController implements MapProviderController {
+  _TemplateMapProviderController(List<MapMarker> initialMarkers)
+      : _markers = ValueNotifier<List<MapMarker>>(List.of(initialMarkers)),
+        _selectedMarker = ValueNotifier<MapMarker?>(null);
+
+  final ValueNotifier<List<MapMarker>> _markers;
+  final ValueNotifier<MapMarker?> _selectedMarker;
+
+  @override
+  ValueNotifier<MapMarker?> get selectedMarker => _selectedMarker;
+
+  @override
+  Future<void> moveTo(MapCoordinate position, {double? zoom}) async {}
+
+  @override
+  Future<void> setMarkers(List<MapMarker> markers) async {
+    _markers.value = List<MapMarker>.unmodifiable(markers);
+  }
+
+  @override
+  Future<void> highlightMarker(String markerId) async {
+    if (markerId.isEmpty) {
+      _selectedMarker.value = null;
+      return;
+    }
+    MapMarker? match;
+    for (final marker in _markers.value) {
+      if (marker.id == markerId) {
+        match = marker;
+        break;
+      }
+    }
+    _selectedMarker.value = match;
+  }
+
+  @override
+  Future<void> fitBounds(List<MapMarker> markers) async {}
+
+  @override
+  void dispose() {
+    _markers.dispose();
+    _selectedMarker.dispose();
+  }
+
+  ValueNotifier<List<MapMarker>> get markers => _markers;
+}
 
 abstract class TemplateMapProvider implements MapProvider {
   const TemplateMapProvider({required this.type, required this.displayName});
@@ -16,13 +64,16 @@ abstract class TemplateMapProvider implements MapProvider {
 
   String get integrationHint;
 
-  @override
-  Widget buildMap(MapViewRequest request) {
-    return MapProviderPlaceholder(
-      providerName: displayName,
-      markers: request.markers,
-      markerCustomizer: request.markerCustomizer,
-      description: integrationHint,
+  MapProviderView buildView(MapViewRequest request) {
+    final controller = _TemplateMapProviderController(request.markers);
+    return MapProviderView(
+      map: MapProviderPlaceholder(
+        providerName: displayName,
+        markersListenable: controller.markers,
+        markerCustomizer: request.markerCustomizer,
+        description: integrationHint,
+      ),
+      controller: controller,
     );
   }
 }


### PR DESCRIPTION
## Summary
- convert the dashboard into a map-first workflow with provider selection, search, and marker navigation panels
- add an OpenStreetMap-backed provider using flutter_map and expand the shared map provider contract to expose controller operations
- refresh templates, registry wiring, and documentation to reflect the interactive map experience

## Testing
- Not run (Flutter tooling unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8e75fe3d8832ab647fb19118b4f9e