### PR TITLE
feat: integrate Naver Map provider into map switcher

### DIFF
--- a/apps/map_switcher/README.md
+++ b/apps/map_switcher/README.md
@@ -5,5 +5,21 @@ Shared map experience demonstrating runtime provider swapping within the SpiralD
 ## Highlights
 
 - Interactive OpenStreetMap implementation with panning, zooming, and marker overlays.
+- 네이버 지도 Open API 연동(클라이언트 ID 설정 시 활성화)으로 실제 네이버 지도를 확인할 수 있습니다.
 - Provider registry architecture that allows runtime switching between real SDK integrations and placeholder templates.
 - Searchable location catalog with quick navigation controls that drive the active map provider.
+
+## Naver Map Open API 설정
+
+네이버 지도 제공자를 사용하려면 [네이버 클라우드 플랫폼](https://www.ncloud.com/)에서 발급한 클라이언트 ID(및 필요 시 시크릿)를 실행 시점에 전달해야 합니다.
+
+1. `NAVER_MAP_CLIENT_ID`와 선택적으로 `NAVER_MAP_CLIENT_SECRET` 값을 준비합니다.
+2. 앱을 실행할 때 아래와 같이 `--dart-define` 인자를 추가합니다.
+
+```bash
+flutter run \
+  --dart-define=NAVER_MAP_CLIENT_ID=YOUR_CLIENT_ID \
+  --dart-define=NAVER_MAP_CLIENT_SECRET=YOUR_CLIENT_SECRET
+```
+
+클라이언트 ID가 설정되지 않은 경우 기존과 동일하게 템플릿 설명 화면이 표시됩니다.

--- a/apps/map_switcher/lib/app/map_switcher_dependencies.dart
+++ b/apps/map_switcher/lib/app/map_switcher_dependencies.dart
@@ -5,6 +5,7 @@ import 'package:ui_components/ui_components.dart';
 import 'package:utils/utils.dart';
 
 import '../features/dashboard/presentation/pages/map_dashboard_page.dart';
+import '../features/map/providers/naver_map_provider.dart';
 import '../features/map/providers/open_street_map_provider.dart';
 import '../features/providers/presentation/pages/provider_catalog_page.dart';
 
@@ -26,13 +27,29 @@ class MapSwitcherDependencies {
   });
 
   static Future<MapSwitcherDependencies> bootstrap() async {
-    final registry = MapProviderRegistry(
-      providers: [
-        OpenStreetMapProvider(),
-        const GoogleMapsProviderTemplate(),
+    final naverClientId =
+        const String.fromEnvironment('NAVER_MAP_CLIENT_ID', defaultValue: '');
+    final naverClientSecret = const String.fromEnvironment(
+      'NAVER_MAP_CLIENT_SECRET',
+      defaultValue: '',
+    );
+
+    final providers = <MapProvider>[
+      OpenStreetMapProvider(),
+      if (naverClientId.isNotEmpty)
+        NaverMapProvider(
+          clientId: naverClientId,
+          clientSecret:
+              naverClientSecret.isEmpty ? null : naverClientSecret,
+        )
+      else
         const NaverMapsProviderTemplate(),
-        const AmazonLocationProviderTemplate(),
-      ],
+      const GoogleMapsProviderTemplate(),
+      const AmazonLocationProviderTemplate(),
+    ];
+
+    final registry = MapProviderRegistry(
+      providers: providers,
     );
     await registry.initializeActive();
 

--- a/apps/map_switcher/lib/features/map/providers/naver_map_provider.dart
+++ b/apps/map_switcher/lib/features/map/providers/naver_map_provider.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:naver_map_plugin/naver_map_plugin.dart';
+import 'package:utils/utils.dart';
+
+class NaverMapProvider implements MapProvider {
+  NaverMapProvider({
+    required this.clientId,
+    this.clientSecret,
+    NaverMapSdk? sdk,
+  })  : assert(clientId.isNotEmpty, 'clientId must not be empty'),
+        _sdk = sdk ?? NaverMapSdk.instance;
+
+  final String clientId;
+  final String? clientSecret;
+  final NaverMapSdk _sdk;
+  bool _initialized = false;
+
+  @override
+  MapProviderType get type => MapProviderType.naver;
+
+  @override
+  String get displayName => 'Naver Map';
+
+  @override
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    await _sdk.initialize(
+      clientId: clientId,
+      clientSecret: clientSecret,
+      onAuthFailed: (error) {
+        debugPrint('Naver Map authentication failed: $error');
+      },
+    );
+    _initialized = true;
+  }
+
+  @override
+  MapProviderView buildView(MapViewRequest request) {
+    final markers = ValueNotifier<List<MapMarker>>(<MapMarker>[]);
+    final selectedMarker = ValueNotifier<MapMarker?>(null);
+    final controller = _NaverMapController(
+      markers: markers,
+      selectedMarker: selectedMarker,
+    );
+
+    return MapProviderView(
+      map: _NaverMapView(
+        controller: controller,
+        markers: markers,
+        selectedMarker: selectedMarker,
+        request: request,
+      ),
+      controller: controller,
+    );
+  }
+}
+
+class _NaverMapController implements MapProviderController {
+  _NaverMapController({
+    required ValueNotifier<List<MapMarker>> markers,
+    required ValueNotifier<MapMarker?> selectedMarker,
+  })  : _markers = markers,
+        _selectedMarker = selectedMarker;
+
+  final ValueNotifier<List<MapMarker>> _markers;
+  final ValueNotifier<MapMarker?> _selectedMarker;
+  final Completer<NaverMapController> _mapControllerCompleter =
+      Completer<NaverMapController>();
+
+  @override
+  ValueNotifier<MapMarker?> get selectedMarker => _selectedMarker;
+
+  void attachMapController(NaverMapController controller) {
+    if (_mapControllerCompleter.isCompleted) {
+      return;
+    }
+    _mapControllerCompleter.complete(controller);
+  }
+
+  Future<NaverMapController> get _mapController async {
+    return _mapControllerCompleter.future;
+  }
+
+  @override
+  Future<void> moveTo(MapCoordinate position, {double? zoom}) async {
+    final controller = await _mapController;
+    final targetZoom = zoom ?? (await controller.getCameraPosition()).zoom;
+    await controller.moveCamera(
+      CameraUpdate.toCameraPosition(
+        CameraPosition(
+          target: LatLng(position.latitude, position.longitude),
+          zoom: targetZoom,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Future<void> setMarkers(List<MapMarker> markers) async {
+    _markers.value = List<MapMarker>.unmodifiable(markers);
+  }
+
+  @override
+  Future<void> highlightMarker(String markerId) async {
+    if (markerId.isEmpty) {
+      _selectedMarker.value = null;
+      return;
+    }
+    _selectedMarker.value =
+        _markers.value.firstWhereOrNull((marker) => marker.id == markerId);
+  }
+
+  @override
+  Future<void> fitBounds(List<MapMarker> markers) async {
+    if (markers.isEmpty) {
+      return;
+    }
+    if (markers.length == 1) {
+      await moveTo(markers.first.position, zoom: 14);
+      return;
+    }
+
+    final controller = await _mapController;
+    final latitudes = markers.map((marker) => marker.position.latitude);
+    final longitudes = markers.map((marker) => marker.position.longitude);
+
+    final southWest = LatLng(
+      latitudes.reduce(min),
+      longitudes.reduce(min),
+    );
+    final northEast = LatLng(
+      latitudes.reduce(max),
+      longitudes.reduce(max),
+    );
+
+    await controller.moveCamera(
+      CameraUpdate.fitBounds(
+        LatLngBounds(southWest, northEast),
+        padding: 48,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _markers.dispose();
+    _selectedMarker.dispose();
+  }
+}
+
+class _NaverMapView extends StatefulWidget {
+  const _NaverMapView({
+    required this.controller,
+    required this.markers,
+    required this.selectedMarker,
+    required this.request,
+  });
+
+  final _NaverMapController controller;
+  final ValueNotifier<List<MapMarker>> markers;
+  final ValueNotifier<MapMarker?> selectedMarker;
+  final MapViewRequest request;
+
+  @override
+  State<_NaverMapView> createState() => _NaverMapViewState();
+}
+
+class _NaverMapViewState extends State<_NaverMapView> {
+  late final double _initialZoom = widget.request.initialZoom ?? 12.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final initialPosition = widget.request.initialCenter ??
+        (widget.markers.value.isNotEmpty
+            ? widget.markers.value.first.position
+            : const MapCoordinate(latitude: 37.5665, longitude: 126.9780));
+
+    return Stack(
+      children: [
+        ValueListenableBuilder<List<MapMarker>>(
+          valueListenable: widget.markers,
+          builder: (context, markers, _) {
+            return NaverMap(
+              onMapCreated: widget.controller.attachMapController,
+              initialCameraPosition: CameraPosition(
+                target: LatLng(
+                  initialPosition.latitude,
+                  initialPosition.longitude,
+                ),
+                zoom: _initialZoom,
+              ),
+              onMapTap: (point, latLng) {
+                widget.selectedMarker.value = null;
+              },
+              markers: markers
+                  .map((marker) => _buildMarker(context, marker))
+                  .toSet(),
+            );
+          },
+        ),
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 16,
+          child: ValueListenableBuilder<MapMarker?>(
+            valueListenable: widget.selectedMarker,
+            builder: (context, marker, _) {
+              if (marker == null) {
+                return const SizedBox.shrink();
+              }
+              return DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      blurRadius: 12,
+                      color: Colors.black.withOpacity(0.2),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: widget.request.markerCustomizer
+                      .buildMarkerDetail(context, marker),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Marker _buildMarker(BuildContext context, MapMarker marker) {
+    return Marker(
+      markerId: MarkerId(marker.id),
+      position: LatLng(
+        marker.position.latitude,
+        marker.position.longitude,
+      ),
+      captionText: marker.info?.title ?? marker.id,
+      onMarkerTab: (overlay, iconSize) {
+        widget.selectedMarker.value = marker;
+        return true;
+      },
+    );
+  }
+}
+
+extension on Iterable<MapMarker> {
+  MapMarker? firstWhereOrNull(bool Function(MapMarker marker) predicate) {
+    for (final marker in this) {
+      if (predicate(marker)) {
+        return marker;
+      }
+    }
+    return null;
+  }
+}

--- a/apps/map_switcher/pubspec.yaml
+++ b/apps/map_switcher/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     path: ../../packages/utils
   flutter_map: ^5.1.0
   latlong2: ^0.9.0
+  naver_map_plugin: ^0.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a concrete Naver Map provider backed by the naver_map_plugin Open API and expose map interactions
- register the provider in the dependency bootstrapper when NAVER_MAP_* credentials are supplied, falling back to the template otherwise
- document credential configuration requirements for enabling the Naver map integration

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea15830478832a96911172cdaac67c