### PR TITLE
feat: default to Korean and add quote surface previews

### DIFF
--- a/apps/quote_companion/lib/src/app.dart
+++ b/apps/quote_companion/lib/src/app.dart
@@ -13,6 +13,19 @@ class QuoteCompanionApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Quote Companion',
+      locale: const Locale('ko'),
+      localeResolutionCallback:
+          (Locale? locale, Iterable<Locale> supportedLocales) {
+        if (locale == null) {
+          return const Locale('ko');
+        }
+        for (final Locale supported in supportedLocales) {
+          if (supported.languageCode == locale.languageCode) {
+            return supported;
+          }
+        }
+        return const Locale('ko');
+      },
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,

--- a/apps/quote_companion/lib/src/presentation/l10n/app_localizations.dart
+++ b/apps/quote_companion/lib/src/presentation/l10n/app_localizations.dart
@@ -28,6 +28,8 @@ class AppLocalizations {
       'ratingLabel': 'Satisfaction (1-5)',
       'emailHint': 'Email (optional)',
       'emptyQuotesPlaceholder': 'Add a quote to see it here.',
+      'previewHeader': 'Preview surfaces',
+      'surfaceDisabledHint': 'Enable this surface above to preview.',
     },
     'ko': <String, String>{
       'appTitle': '명언 컴패니언',
@@ -47,6 +49,8 @@ class AppLocalizations {
       'ratingLabel': '만족도 (1-5)',
       'emailHint': '이메일 (선택)',
       'emptyQuotesPlaceholder': '추가한 명언이 여기에 보여요.',
+      'previewHeader': '미리보기',
+      'surfaceDisabledHint': '위에서 활성화하면 미리보기가 제공돼요.',
     },
     'ja': <String, String>{
       'appTitle': 'クォートコンパニオン',
@@ -66,6 +70,8 @@ class AppLocalizations {
       'ratingLabel': '満足度 (1-5)',
       'emailHint': 'メール (任意)',
       'emptyQuotesPlaceholder': 'ここに名言が表示されます。',
+      'previewHeader': 'プレビュー',
+      'surfaceDisabledHint': '上部で有効にするとプレビューできます。',
     },
   };
 
@@ -83,7 +89,7 @@ class AppLocalizations {
   /// Convenience lookup for widgets.
   static AppLocalizations of(BuildContext context) {
     return Localizations.of<AppLocalizations>(context, AppLocalizations) ??
-        AppLocalizations(const Locale('en'));
+        AppLocalizations(const Locale('ko'));
   }
 
   /// Looks up a localized string.

--- a/apps/quote_companion/lib/src/presentation/pages/quote_dashboard_page.dart
+++ b/apps/quote_companion/lib/src/presentation/pages/quote_dashboard_page.dart
@@ -7,6 +7,7 @@ import '../l10n/app_localizations.dart';
 import '../state/quote_notifier.dart';
 import '../state/quote_state.dart';
 import '../widgets/quote_card.dart';
+import '../widgets/quote_surface_previews.dart';
 
 /// Home screen showcasing inspirational quotes and controls.
 class QuoteDashboardPage extends ConsumerStatefulWidget {
@@ -207,6 +208,13 @@ class _QuoteDashboardPageState extends ConsumerState<QuoteDashboardPage> {
                 await notifier.updateRefreshInterval(value.toInt());
               },
             ),
+            if (state.activeQuote != null) ...<Widget>[
+              const SizedBox(height: 24),
+              QuoteSurfacePreviews(
+                quote: state.activeQuote!,
+                preferences: state.preferences,
+              ),
+            ],
             const SizedBox(height: 24),
             Text(
               l10n.translate('feedbackHeader'),

--- a/apps/quote_companion/lib/src/presentation/widgets/quote_surface_previews.dart
+++ b/apps/quote_companion/lib/src/presentation/widgets/quote_surface_previews.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/quote.dart';
+import '../../domain/entities/quote_display_preferences.dart';
+import '../l10n/app_localizations.dart';
+
+/// Visual previews for configured quote surfaces such as the status bar
+/// and home widget. The previews help validate toggles without requiring
+/// a full device integration.
+class QuoteSurfacePreviews extends StatelessWidget {
+  /// Creates a [QuoteSurfacePreviews] widget.
+  const QuoteSurfacePreviews({
+    super.key,
+    required this.quote,
+    required this.preferences,
+  });
+
+  /// Quote currently highlighted by the experience.
+  final Quote quote;
+
+  /// User's configured display preferences.
+  final QuoteDisplayPreferences preferences;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations l10n = AppLocalizations.of(context);
+
+    final List<Widget> children = <Widget>[
+      Text(
+        l10n.translate('previewHeader'),
+        style: theme.textTheme.titleMedium,
+      ),
+      const SizedBox(height: 12),
+      if (preferences.isTargetEnabled(QuoteDisplayTarget.statusBar))
+        _StatusBarPreview(quote: quote, l10n: l10n)
+      else
+        _SurfaceDisabledNotice(title: l10n.translate('statusBarLabel')),
+      const SizedBox(height: 12),
+      if (preferences.isTargetEnabled(QuoteDisplayTarget.homeWidget))
+        _HomeWidgetPreview(quote: quote, l10n: l10n)
+      else
+        _SurfaceDisabledNotice(title: l10n.translate('homeWidgetLabel')),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: children,
+    );
+  }
+}
+
+class _StatusBarPreview extends StatelessWidget {
+  const _StatusBarPreview({required this.quote, required this.l10n});
+
+  final Quote quote;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color foreground = theme.colorScheme.onPrimary;
+    final String author =
+        quote.author.isEmpty ? l10n.translate('appTitle') : quote.author;
+
+    return Semantics(
+      label: 'status-bar-preview',
+      container: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primary,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.format_quote_rounded, size: 16, color: foreground),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  quote.text,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelLarge?.copyWith(color: foreground),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                author,
+                style:
+                    theme.textTheme.labelSmall?.copyWith(color: foreground),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeWidgetPreview extends StatelessWidget {
+  const _HomeWidgetPreview({required this.quote, required this.l10n});
+
+  final Quote quote;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String author =
+        quote.author.isEmpty ? l10n.translate('appTitle') : quote.author;
+
+    return Semantics(
+      label: 'home-widget-preview',
+      container: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: theme.colorScheme.surfaceVariant,
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                l10n.translate('homeWidgetLabel'),
+                style: theme.textTheme.labelMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '“${quote.text}”',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  '— $author',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SurfaceDisabledNotice extends StatelessWidget {
+  const _SurfaceDisabledNotice({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AppLocalizations l10n = AppLocalizations.of(context);
+
+    return Semantics(
+      label: 'surface-disabled',
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+        ),
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: <Widget>[
+            Icon(Icons.visibility_off_outlined,
+                color: theme.colorScheme.outline),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                '$title · ${l10n.translate('surfaceDisabledHint')}',
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- default the Quote Companion application to Korean and ensure the fallback localization matches
- add localized copy for surface previews and introduce a preview widget for status bar and home widget targets
- render the new previews from the dashboard so status bar and widget targets can be validated visually

## Testing
- flutter test *(fails: Flutter SDK is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb384c4824832aadca98e165b7b298