### PR TITLE
feat: surface active quote in mobile notifications

### DIFF
--- a/apps/quote_companion/android/app/src/main/AndroidManifest.xml
+++ b/apps/quote_companion/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="quote_companion"
         android:name="${applicationName}"

--- a/apps/quote_companion/ios/Runner/Info.plist
+++ b/apps/quote_companion/ios/Runner/Info.plist
@@ -45,7 +45,9 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSUserNotificationUsageDescription</key>
+        <string>We use notifications to keep your inspirational quote handy.</string>
 </dict>
 </plist>

--- a/apps/quote_companion/lib/src/di/providers.dart
+++ b/apps/quote_companion/lib/src/di/providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/datasources/quote_local_data_source.dart';
@@ -10,6 +11,7 @@ import '../domain/usecases/refresh_active_quote.dart';
 import '../domain/usecases/remove_custom_quote.dart';
 import '../domain/usecases/submit_feedback.dart';
 import '../domain/usecases/watch_active_quote.dart';
+import '../presentation/services/quote_notification_service.dart';
 
 /// Provider for the local data source.
 final quoteLocalDataSourceProvider = Provider<QuoteLocalDataSource>((ref) {
@@ -21,6 +23,20 @@ final quoteRepositoryProvider = Provider<QuoteRepository>((ref) {
   final QuoteLocalDataSource dataSource =
       ref.watch(quoteLocalDataSourceProvider);
   return QuoteRepositoryImpl(localDataSource: dataSource);
+});
+
+/// Provider for the Flutter local notifications plugin.
+final flutterLocalNotificationsPluginProvider =
+    Provider<FlutterLocalNotificationsPlugin>((ref) {
+  return FlutterLocalNotificationsPlugin();
+});
+
+/// Provider for the notification service that mirrors the active quote.
+final quoteNotificationServiceProvider =
+    Provider<QuoteNotificationService>((ref) {
+  final FlutterLocalNotificationsPlugin plugin =
+      ref.watch(flutterLocalNotificationsPluginProvider);
+  return QuoteNotificationService(plugin);
 });
 
 /// Watch active quote use-case provider.

--- a/apps/quote_companion/lib/src/presentation/services/quote_notification_service.dart
+++ b/apps/quote_companion/lib/src/presentation/services/quote_notification_service.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../../domain/entities/quote.dart';
+
+/// Handles rendering the currently active quote as a system notification.
+class QuoteNotificationService {
+  QuoteNotificationService(this._notificationsPlugin);
+
+  static const int _notificationId = 9001;
+  static const String _androidChannelId = 'quote_companion_persistent_quote';
+  static const AndroidNotificationChannel _androidChannel =
+      AndroidNotificationChannel(
+    _androidChannelId,
+    'Daily inspiration',
+    description: 'Keeps the latest quote visible in the status bar.',
+    importance: Importance.high,
+    playSound: false,
+    enableVibration: false,
+    showBadge: false,
+  );
+
+  final FlutterLocalNotificationsPlugin _notificationsPlugin;
+  bool _initialised = false;
+
+  /// Ensures the underlying platform integrations are ready.
+  Future<void> ensureInitialized() async {
+    if (_initialised) {
+      return;
+    }
+
+    if (kIsWeb) {
+      _initialised = true;
+      return;
+    }
+
+    const AndroidInitializationSettings androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const DarwinInitializationSettings iosSettings =
+        DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: false,
+      requestSoundPermission: true,
+    );
+    const InitializationSettings initializationSettings =
+        InitializationSettings(android: androidSettings, iOS: iosSettings);
+
+    await _notificationsPlugin.initialize(initializationSettings);
+
+    if (Platform.isAndroid) {
+      final AndroidFlutterLocalNotificationsPlugin? androidPlugin =
+          _notificationsPlugin.resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
+      await androidPlugin?.createNotificationChannel(_androidChannel);
+    } else if (Platform.isIOS) {
+      final IOSFlutterLocalNotificationsPlugin? iosPlugin =
+          _notificationsPlugin.resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>();
+      await iosPlugin?.requestPermissions(alert: true, badge: false, sound: true);
+    }
+
+    _initialised = true;
+  }
+
+  /// Displays the provided [quote] as a persistent notification.
+  Future<void> showQuote(Quote quote) async {
+    await ensureInitialized();
+
+    if (kIsWeb || (!Platform.isAndroid && !Platform.isIOS)) {
+      return;
+    }
+
+    final String title = quote.author.isEmpty ? 'Quote Companion' : quote.author;
+    final AndroidNotificationDetails androidDetails =
+        AndroidNotificationDetails(
+      _androidChannel.id,
+      _androidChannel.name,
+      channelDescription: _androidChannel.description,
+      priority: Priority.high,
+      importance: Importance.high,
+      ongoing: true,
+      autoCancel: false,
+      category: AndroidNotificationCategory.reminder,
+      showWhen: false,
+      visibility: NotificationVisibility.public,
+      icon: '@mipmap/ic_launcher',
+      styleInformation: BigTextStyleInformation(
+        '“${quote.text}”',
+        contentTitle: title,
+      ),
+    );
+
+    const DarwinNotificationDetails iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentSound: true,
+    );
+
+    final NotificationDetails platformDetails = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notificationsPlugin.show(
+      _notificationId,
+      title,
+      '“${quote.text}”',
+      platformDetails,
+      payload: quote.id,
+    );
+  }
+
+  /// Clears the persistent notification.
+  Future<void> clearQuote() async {
+    if (!_initialised) {
+      return;
+    }
+    if (kIsWeb || (!Platform.isAndroid && !Platform.isIOS)) {
+      return;
+    }
+    await _notificationsPlugin.cancel(_notificationId);
+  }
+}

--- a/apps/quote_companion/lib/src/presentation/state/quote_notifier.dart
+++ b/apps/quote_companion/lib/src/presentation/state/quote_notifier.dart
@@ -13,6 +13,7 @@ import '../../domain/usecases/refresh_active_quote.dart';
 import '../../domain/usecases/remove_custom_quote.dart';
 import '../../domain/usecases/submit_feedback.dart';
 import '../../domain/usecases/watch_active_quote.dart';
+import '../services/quote_notification_service.dart';
 import 'quote_state.dart';
 
 /// Riverpod notifier backing the quote dashboard UI.
@@ -26,6 +27,7 @@ class QuoteNotifier extends StateNotifier<QuoteState> {
     this._fetchCustomQuotes,
     this._submitFeedback,
     this._loadFeedbackHistory,
+    this._notificationService,
   ) : super(QuoteState.initial()) {
     _initialize();
   }
@@ -37,14 +39,17 @@ class QuoteNotifier extends StateNotifier<QuoteState> {
   final FetchCustomQuotes _fetchCustomQuotes;
   final SubmitFeedback _submitFeedback;
   final LoadFeedbackHistory _loadFeedbackHistory;
+  final QuoteNotificationService _notificationService;
   final Uuid _uuid = const Uuid();
 
   StreamSubscription<Quote>? _quoteSubscription;
 
   Future<void> _initialize() async {
     state = state.copyWith(isLoading: true);
+    await _notificationService.ensureInitialized();
     _quoteSubscription = _watchActiveQuote().listen((Quote quote) {
       state = state.copyWith(activeQuote: quote, isLoading: false);
+      unawaited(_notificationService.showQuote(quote));
     });
     final List<Quote> customQuotes = await _fetchCustomQuotes();
     final List<FeedbackEntry> feedbackHistory =
@@ -59,6 +64,7 @@ class QuoteNotifier extends StateNotifier<QuoteState> {
   @override
   void dispose() {
     _quoteSubscription?.cancel();
+    unawaited(_notificationService.clearQuote());
     super.dispose();
   }
 
@@ -115,5 +121,6 @@ final quoteNotifierProvider =
     ref.watch(fetchCustomQuotesProvider),
     ref.watch(submitFeedbackProvider),
     ref.watch(loadFeedbackHistoryProvider),
+    ref.watch(quoteNotificationServiceProvider),
   );
 });

--- a/apps/quote_companion/pubspec.yaml
+++ b/apps/quote_companion/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   equatable: ^2.0.5
   flutter_riverpod: ^2.4.9
+  flutter_local_notifications: ^17.1.2
   shared_preferences: ^2.2.2
   flutter_secure_storage: ^9.0.0
   uuid: ^4.2.1


### PR DESCRIPTION
## Summary
- add a quote notification service backed by flutter_local_notifications
- display the active quote as a persistent Android status bar item and iOS notification center entry
- request required platform permissions and wire the service into the quote notifier

## Testing
- not run (flutter SDK is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee7082454c832ab0c961126138e181